### PR TITLE
fix(#23): replace daily publish guard with spreadsheet-based career post check

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,6 +12,20 @@ Content manager for Whitney Lee's content publishing workflow. Syncs career cont
 
 Service account email: `content-manager-sheets@demoo-ooclock.iam.gserviceaccount.com`
 
+## Post Type Taxonomy
+
+Whitney publishes three distinct types of posts. This system manages the first two.
+
+| Type | Managed by | Destination | Cadence |
+|---|---|---|---|
+| **Career posts** | `sync-content.js` (this repo) | Micro.blog → syndicates to Bluesky, Mastodon, LinkedIn | When new career content is ready (podcasts, talks, videos) |
+| **Social posts** | `post-social-content.js` (this repo) | LinkedIn, Bluesky, Mastodon, micro.blog directly | Scheduled via Social Posts Queue tab |
+| **Personal posts** | Whitney manually, via Micro.blog UI | Micro.blog → syndicates to Bluesky, Mastodon, LinkedIn | Ad hoc |
+
+**Daily limit**: one managed post per day collectively (career OR social, not both). Personal posts are exempt — they can appear on the same day as a managed post.
+
+**Priority**: career > social. Career runs first and posts freely. Social runs second and defers if career already posted that day. The daily publish guard belongs in the social step, not the career step. See issue #23 for implementation design.
+
 ## Content Sources to Monitor
 
 1. **YouTube - wiggitywhitney channel** (`UCaGYZkSCN3MPwqRpt24KBKA`)

--- a/.github/workflows/daily-sync.yml
+++ b/.github/workflows/daily-sync.yml
@@ -41,8 +41,6 @@ jobs:
           MICROBLOG_APP_TOKEN: ${{ secrets.MICROBLOG_APP_TOKEN }}
           MICROBLOG_XMLRPC_TOKEN: ${{ secrets.MICROBLOG_XMLRPC_TOKEN }}
           MICROBLOG_USERNAME: ${{ secrets.MICROBLOG_USERNAME }}
-          BLUESKY_HANDLE: ${{ secrets.BLUESKY_HANDLE }}
-          BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}
         run: node src/sync-content.js
 
       - name: Post social content

--- a/journal/entries/2026-04/2026-04-08.md
+++ b/journal/entries/2026-04/2026-04-08.md
@@ -1,0 +1,91 @@
+
+
+## 6:20:37 AM GMT+1 - Commit: 200480b1 - docs: add post type taxonomy and daily posting priority to CLAUDE.md
+
+### Summary - 200480b1
+
+The developer added a post type taxonomy and daily posting priority to the CLAUDE.md file, enhancing the documentation to clarify the management of different types of posts. During the session, the developer discussed the implications of the posting order for career and social content, recognizing a potential conflict in the existing system that could prevent necessary posts from being published. The conversation led to the conclusion that the career posts should take priority, with social posts deferring if a career post is made on the same day.
+
+The developer noted that the previous checks were no longer relevant due to updates in the content management process, specifically the integration of LinkedIn for syndication. This shift meant that the rules around posting frequency could be simplified, allowing both career and social posts to coexist without restrictions. The developer and the AI assistant analyzed the necessary adjustments to the code, determining that the solution would involve removing the outdated check that relied on Bluesky as a proxy for posting limits.
+
+Additionally, the session included the extraction of redundant information from the documentation to streamline the content manager's memory and ensure clarity in the CLAUDE.md files. The developer decided to leave some of the documentation adjustments to be made in the Journal repository while taking care to commit the changes made in the content manager. Overall, the session effectively addressed the need for clearer documentation and a more efficient posting strategy, resulting in actionable changes to the project's management system.
+
+### Development Dialogue - 200480b1
+
+> **Human:** "Oh yes, I see. The problem is right now I have it arranged where social posts come first because I don't always have social posts ready, and career comes second. But once I had this system going, I should have social posts every single day, which means career stuff would never get posted. So I think the answer is to post career first. And if something from career got posted, then don't post socials. FYI, I enabled LinkedIn to get downstream micro.blog posts. So if we ever post there, it'll auto post across all three social channels. Since all of the content is getting managed from the spreadsheet, I don't know if the check is needed anymore at all. [...]"
+
+> **Human:** "The distinction between the three types of post is worth committing to memory and even your project Claude.md and probably the Claude.md in the Documents/Journal repo too."
+
+> **Human:** "One and two make sense. Three should not live in your memory. In Journal's memory maaaaaybe."
+
+### Technical Decisions - 200480b1
+
+- **DECISION: Post Type Taxonomy and Daily Posting Priority** (Discussed) - FILES: .claude/CLAUDE.md
+  - The original guard is now obsolete.
+  - The check used Bluesky as a proxy to detect "did I already post today?"
+  - The cleaner fix: replace the Bluesky proxy with a direct check.
+  - The rule: one managed post per day collectively across career + social. Personal posts from the Micro.blog UI are exempt — they can coexist.
+  - The social step needs a way to detect whether career ran. 
+  - The fix is simpler than any of the options listed in the issue. Just delete the daily publish guard from `sync-content.js`.
+
+### Commit Details - 200480b1
+
+**Files Changed**:
+- .claude/CLAUDE.md
+
+**Lines Changed**: ~14 lines
+**Message**: "docs: add post type taxonomy and daily posting priority to CLAUDE.md"
+
+═══════════════════════════════════════
+
+
+
+## 6:45:44 AM GMT+1 - Commit: afe468ba - fix(#23): replace Bluesky/Micro.blog proxy guard with spreadsheet-based career post check
+
+### Summary - afe468ba
+
+The update replaced the existing Bluesky and Micro.blog proxy guard in the daily content synchronization system with a new, spreadsheet-based check focused on career posts. This change streamlined the process, allowing career-related content to be posted without a guard, while the social media posting step now checks whether any career content has been posted on the same day.
+
+The developer discussed the initial problem with the daily publish guard, where the old method was deemed unnecessary. They proposed a more straightforward solution: instead of tracking state through job outputs or temporary files, the system would write the date of the last career post directly into a new column in the spreadsheet. This approach simplifies the logic and provides an audit trail, as the spreadsheet can now show when each career item was posted. The decision to add a timestamp for each posting rather than just a flag enables better tracking and allows for historical queries about when specific content was shared.
+
+During the implementation, the developer removed two functions that were no longer needed—those checking if posts were published today on Bluesky and Micro.blog. They refactored the code to update the spreadsheet directly when a career post was made, ensuring that the social media posting function can easily check the new timestamp column before dispatching any posts.
+
+The developer also wrote and confirmed tests to ensure that the new functionality worked as intended, including tests for skipping social posts if a career post had already been made that day. They made sure all changes were covered by the tests, and upon running them, all passed successfully.
+
+In the course of these discussions, the developer showed flexibility in their approach, initially considering a more complex solution but ultimately opting for a simpler and cleaner design that leverages existing resources effectively. This session highlighted the ability to adapt and simplify system designs in response to project requirements, which is a critical skill in software development.
+
+### Development Dialogue - afe468ba
+
+> **Human:** "I don't think we need state tracking. In the career post, at least, the microblog post gives a URL for anything that's posted, but we're dealing with a freaking spreadsheet that tracks dates. We could just put a column on the spreadsheet that has a check mark when something gets posted."
+> **Assistant:** "[...] The spreadsheet IS the state. When `sync-content.js` posts a career item to Micro.blog, it already gets back a URL. Write today's date (or the URL) to a new column on that row. Then `post-social-content.js` just asks: 'does any row in the live spreadsheet have a posted-date of today?' If yes, skip."
+
+> **Human:** "Why not add a date and time posted column and update every one as we go?"
+> **Assistant:** "[...] Every time `sync-content.js` posts or updates a row on Micro.blog, write a timestamp to Column I. Over time you get a full history of when each career item was last synced."
+
+### Technical Decisions - afe468ba
+
+- **DECISION: Replace Bluesky/Micro.blog Proxy Guard** (Implemented) - FILES: [src/career-post-guard.js, src/post-social-content.js, src/sync-content.js, .github/workflows/daily-sync.yml]
+  - Career posts freely, no guard
+  - Social step checks if career posted today before firing
+  - Removed old Bluesky proxy check
+  - Added Column I as "Micro.blog Posted At" to track posting dates
+  - Updates to `sync-content.js` to write timestamps to Column I
+  - `post-social-content.js` checks Column I for today's date before dispatching
+  - Simplifies implementation without state tracking or job outputs
+  - Provides a visible audit trail in the spreadsheet
+
+### Commit Details - afe468ba
+
+**Files Changed**:
+- .github/workflows/daily-sync.yml
+- src/career-post-guard.js
+- src/post-social-content.js
+- src/sync-content.js
+- test/career-post-guard.test.js
+- test/post-social-content.test.js
+
+**Lines Changed**: ~455 lines
+**Message**: "fix(#23): replace Bluesky/Micro.blog proxy guard with spreadsheet-based career post check"
+
+═══════════════════════════════════════
+

--- a/src/career-post-guard.js
+++ b/src/career-post-guard.js
@@ -1,0 +1,62 @@
+// ABOUTME: Checks whether career content was posted to Micro.blog today by reading the live spreadsheet.
+// ABOUTME: Used by post-social-content.js to enforce the one-managed-post-per-day rule (career > social).
+
+'use strict';
+
+const { google } = require('googleapis');
+
+// Live production spreadsheet — career content rows, Column I = "Micro.blog Posted At" timestamp
+const LIVE_SPREADSHEET_ID = '1E10fSvDbcDdtNNtDQ9QtydUXSBZH2znY6ztIxT4fwVs';
+const SHEET_NAME = process.env.SHEET_NAME || 'Sheet1';
+
+/**
+ * Returns true if career content was posted to Micro.blog today.
+ *
+ * Reads Column I ("Micro.blog Posted At") of the live production spreadsheet and checks
+ * for any timestamp matching today's UTC date. Returns false (not throws) on any error
+ * so a transient failure does not suppress social posts.
+ *
+ * Personal posts are automatically exempt because Whitney posts those directly via the
+ * Micro.blog UI, which never touches this spreadsheet.
+ *
+ * @returns {Promise<boolean>}
+ */
+async function checkCareerPostedToday() {
+  const serviceAccountJson = process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+  if (!serviceAccountJson) {
+    console.warn('[career-guard] GOOGLE_SERVICE_ACCOUNT_JSON not set — skipping career post check'); // eslint-disable-line no-console
+    return false;
+  }
+
+  try {
+    const credentials = JSON.parse(serviceAccountJson);
+    const auth = new google.auth.GoogleAuth({
+      credentials,
+      scopes: ['https://www.googleapis.com/auth/spreadsheets.readonly'],
+    });
+
+    const sheets = google.sheets({ version: 'v4', auth });
+    const response = await sheets.spreadsheets.values.get({
+      spreadsheetId: LIVE_SPREADSHEET_ID,
+      range: `${SHEET_NAME}!I:I`,
+    });
+
+    const rows = response.data.values || [];
+    const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
+
+    const posted = rows.some(row => {
+      const val = (row[0] || '').trim();
+      return val.startsWith(today);
+    });
+
+    if (posted) {
+      console.log(`[career-guard] Career content already posted today (${today}) — skipping social dispatch`); // eslint-disable-line no-console
+    }
+    return posted;
+  } catch (err) {
+    console.warn(`[career-guard] Error checking career post status: ${err.message} — proceeding with social dispatch`); // eslint-disable-line no-console
+    return false;
+  }
+}
+
+module.exports = { checkCareerPostedToday };

--- a/src/career-post-guard.js
+++ b/src/career-post-guard.js
@@ -7,7 +7,9 @@ const { google } = require('googleapis');
 
 // Live production spreadsheet — career content rows, Column I = "Micro.blog Posted At" timestamp
 const LIVE_SPREADSHEET_ID = '1E10fSvDbcDdtNNtDQ9QtydUXSBZH2znY6ztIxT4fwVs';
+// Must match the tab names used by sync-content.js (respects env overrides)
 const SHEET_NAME = process.env.SHEET_NAME || 'Sheet1';
+const HISTORICAL_TAB_NAME = process.env.HISTORICAL_TAB_NAME || '2024 & earlier';
 
 /**
  * Returns true if career content was posted to Micro.blog today.
@@ -36,15 +38,26 @@ async function checkCareerPostedToday() {
     });
 
     const sheets = google.sheets({ version: 'v4', auth });
-    const response = await sheets.spreadsheets.values.get({
-      spreadsheetId: LIVE_SPREADSHEET_ID,
-      range: `${SHEET_NAME}!I:I`,
-    });
 
-    const rows = response.data.values || [];
+    // Read Column I from both tabs — sync-content.js can write to either
+    const [mainResponse, historicalResponse] = await Promise.all([
+      sheets.spreadsheets.values.get({
+        spreadsheetId: LIVE_SPREADSHEET_ID,
+        range: `${SHEET_NAME}!I:I`,
+      }),
+      sheets.spreadsheets.values.get({
+        spreadsheetId: LIVE_SPREADSHEET_ID,
+        range: `${HISTORICAL_TAB_NAME}!I:I`,
+      }),
+    ]);
+
+    const allRows = [
+      ...(mainResponse.data.values || []),
+      ...(historicalResponse.data.values || []),
+    ];
     const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD UTC
 
-    const posted = rows.some(row => {
+    const posted = allRows.some(row => {
       const val = (row[0] || '').trim();
       return val.startsWith(today);
     });

--- a/src/post-social-content.js
+++ b/src/post-social-content.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const { fetchPendingPostsForToday } = require('./social-posts-queue');
+const { checkCareerPostedToday } = require('./career-post-guard');
 const { postToBluesky } = require('./post-bluesky');
 const { postToMastodon } = require('./post-mastodon');
 const { postToLinkedIn } = require('./post-linkedin');
@@ -78,6 +79,10 @@ async function dispatchPost(post) {
  * @param {string} today - Date in YYYY-MM-DD format
  */
 async function processPostsForDate(today) {
+  if (await checkCareerPostedToday()) {
+    return;
+  }
+
   const pendingPosts = await fetchPendingPostsForToday(today);
 
   if (pendingPosts.length === 0) {

--- a/src/post-social-content.js
+++ b/src/post-social-content.js
@@ -111,11 +111,15 @@ async function main() {
     process.exit(1);
   }
 
-  try {
-    await scanAndPostShorts();
-  } catch (err) {
-    console.error('[social] micro.blog short scan failed:', err.message); // eslint-disable-line no-console
-    // Non-fatal: regular platform dispatch already completed
+  // Career > social priority: also skip the micro.blog short scan if career posted today
+  const careerPostedToday = await checkCareerPostedToday().catch(() => false);
+  if (!careerPostedToday) {
+    try {
+      await scanAndPostShorts();
+    } catch (err) {
+      console.error('[social] micro.blog short scan failed:', err.message); // eslint-disable-line no-console
+      // Non-fatal: regular platform dispatch already completed
+    }
   }
 }
 

--- a/src/sync-content.js
+++ b/src/sync-content.js
@@ -1,6 +1,7 @@
+// ABOUTME: Daily career content sync — reads the live production spreadsheet and creates/updates Micro.blog posts.
+// ABOUTME: Handles post creation, updates, deletions, archive posts, and orphan cleanup.
 const { google } = require('googleapis');
 const https = require('https');
-const { BskyAgent } = require('@atproto/api');
 const { CATEGORY_PAGES } = require('./config/category-pages');
 
 // Rate limiting for Google Sheets writes (60 writes/min quota)
@@ -11,7 +12,7 @@ const SHEETS_WRITE_DELAY_MS = 1500;
 const SPREADSHEET_ID = process.env.SPREADSHEET_ID || '1E10fSvDbcDdtNNtDQ9QtydUXSBZH2znY6ztIxT4fwVs';
 const SHEET_NAME = process.env.SHEET_NAME || 'Sheet1';
 const HISTORICAL_TAB_NAME = process.env.HISTORICAL_TAB_NAME || '2024 & earlier';
-const RANGE = process.env.SHEET_RANGE || `${SHEET_NAME}!A:H`; // Name, Type, Show, Date, Location, Confirmed, Link, Micro.blog URL
+const RANGE = process.env.SHEET_RANGE || `${SHEET_NAME}!A:I`; // Name, Type, Show, Date, Location, Confirmed, Link, Micro.blog URL, Micro.blog Posted At
 
 // Dry-run mode: when enabled, logs actions without making actual API calls
 // Defaults to true (safe) unless explicitly disabled with DRY_RUN=false
@@ -306,32 +307,55 @@ function log(message, level = 'INFO', data = null) {
 }
 
 /**
- * Writes Micro.blog URL back to spreadsheet Column H
+ * Writes Micro.blog URL to Column H and (when posting a new URL) a timestamp to Column I.
+ * Column I ("Micro.blog Posted At") is used by the social posting guard to detect whether
+ * career content ran today. It is only written when a real URL is provided; clearing a URL
+ * (passing an empty string) does not update the timestamp.
+ *
  * @param {Object} sheets - Google Sheets API client
  * @param {string} spreadsheetId - Spreadsheet ID
+ * @param {string} tabName - Tab name (e.g. "Sheet1" or "2024 & earlier")
  * @param {number} rowIndex - 1-based row index (matches spreadsheet row numbers)
- * @param {string} url - Micro.blog post URL from Location header
+ * @param {string} url - Micro.blog post URL from Location header, or '' to clear
  * @returns {Promise<boolean>} - True if successful, false otherwise
  */
 async function writeUrlToSpreadsheet(sheets, spreadsheetId, tabName, rowIndex, url) {
   try {
-    const range = `${tabName}!H${rowIndex}`;  // e.g., "Sheet1!H15" or "2024 & earlier!H42"
-
     if (DRY_RUN) {
-      log(`[DRY-RUN] Would write URL to ${tabName} row ${rowIndex}: ${url}`, 'INFO');
+      log(`[DRY-RUN] Would write URL to ${tabName} row ${rowIndex}: ${url || '(clear)'}`, 'INFO');
       return true;
     }
 
-    await withRetry(
-      () => sheets.spreadsheets.values.update({
-        spreadsheetId,
-        range,
-        valueInputOption: 'USER_ENTERED',
-        resource: { values: [[url]] }
-      }),
-      `Write URL to ${tabName} row ${rowIndex}`
-    );
-    log(`Wrote URL to ${tabName} row ${rowIndex}: ${url}`, 'DEBUG');
+    const writes = [
+      withRetry(
+        () => sheets.spreadsheets.values.update({
+          spreadsheetId,
+          range: `${tabName}!H${rowIndex}`,
+          valueInputOption: 'USER_ENTERED',
+          resource: { values: [[url]] }
+        }),
+        `Write URL to ${tabName} row ${rowIndex}`
+      )
+    ];
+
+    // Write timestamp to Column I when setting a real URL (not when clearing)
+    if (url) {
+      const postedAt = new Date().toISOString();
+      writes.push(
+        withRetry(
+          () => sheets.spreadsheets.values.update({
+            spreadsheetId,
+            range: `${tabName}!I${rowIndex}`,
+            valueInputOption: 'USER_ENTERED',
+            resource: { values: [[postedAt]] }
+          }),
+          `Write posted-at timestamp to ${tabName} row ${rowIndex}`
+        )
+      );
+    }
+
+    await Promise.all(writes);
+    log(`Wrote URL to ${tabName} row ${rowIndex}: ${url || '(cleared)'}`, 'DEBUG');
     return true;
   } catch (error) {
     // Don't fail entire sync if write fails (after retries exhausted)
@@ -564,196 +588,6 @@ async function createMicroblogPost(content, postContent, publishedDate) {
   }
 
   return postUrl;
-}
-
-/**
- * Get today's date range for checking published posts
- * @returns {Object} - { start: ISO string at 00:00 UTC, end: ISO string at 23:59:59 UTC }
- */
-function getTodayDateRange() {
-  const now = new Date();
-
-  // Today's date at 00:00:00 UTC
-  const start = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0));
-
-  // Today's date at 23:59:59 UTC
-  const end = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 23, 59, 59));
-
-  return {
-    start: start.toISOString(),
-    end: end.toISOString()
-  };
-}
-
-/**
- * Check if a post was published to Micro.blog today
- * @returns {Promise<boolean>} - True if a post was published today, false otherwise
- */
-async function checkPublishedToday() {
-  const token = process.env.MICROBLOG_APP_TOKEN;
-  if (!token) {
-    throw new Error('MICROBLOG_APP_TOKEN environment variable not set');
-  }
-
-  try {
-    const { start, end } = getTodayDateRange();
-    const startTime = new Date(start).getTime();
-    const endTime = new Date(end).getTime();
-    const now = new Date();
-    const nowTime = now.getTime();
-    const nowISO = now.toISOString();
-
-    // Query the most recent 20 posts to find the most recent one that's actually published
-    const url = `https://micro.blog/micropub?q=source&limit=20&offset=0`;
-    log(`Daily publish guard: Checking for posts published today (${start.substring(0, 10)} UTC)`, 'INFO');
-
-    const response = await fetch(url, {
-      headers: {
-        'Authorization': `Bearer ${token}`
-      }
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Failed to query posts (${response.status}): ${errorText}`);
-    }
-
-    const data = await response.json();
-    const posts = data.items || [];
-
-    if (posts.length === 0) {
-      log(`No posts found on Micro.blog - will publish`, 'INFO');
-      return false;
-    }
-
-    // Find the most recent post that has actually been published (not scheduled for future)
-    // Note: Assumes API returns posts in reverse chronological order (most recent first)
-    let mostRecentPublishedPost = null;
-    for (const post of posts) {
-      const publishedDate = post.properties?.published?.[0];
-      if (publishedDate) {
-        const publishedTime = new Date(publishedDate).getTime();
-        if (Number.isFinite(publishedTime) && publishedTime <= nowTime) {
-          mostRecentPublishedPost = post;
-          break;  // First one we find is the most recent published
-        }
-      }
-    }
-
-    if (!mostRecentPublishedPost) {
-      log(`No published posts found (only scheduled posts) - will publish`, 'INFO');
-      return false;
-    }
-
-    const publishedDate = mostRecentPublishedPost.properties?.published?.[0];
-
-    // Convert publishedDate to timestamp for numeric comparison (handles timezone offsets)
-    const publishedTime = new Date(publishedDate).getTime();
-    if (!Number.isFinite(publishedTime)) {
-      log(`Most recent post has invalid published date (${publishedDate}) - will publish`, 'WARN');
-      return false;
-    }
-
-    // Check if published date is within today's range using numeric comparison
-    if (publishedTime >= startTime && publishedTime <= endTime) {
-      const postUrl = mostRecentPublishedPost.properties?.url?.[0] || 'unknown';
-      const postTitle = mostRecentPublishedPost.properties?.name?.[0] || mostRecentPublishedPost.properties?.content?.[0]?.substring(0, 50) || 'Untitled';
-      log(`✓ Post exists for today (published): "${postTitle}" at ${publishedDate}`, 'INFO');
-      log(`Daily publish guard: SKIPPING new post (max 1 per day)`, 'WARN');
-      return true;
-    } else {
-      // Post is from the past (not today)
-      log(`Most recent published post is from ${publishedDate.substring(0, 10)} (not today) - will publish`, 'INFO');
-      return false;
-    }
-  } catch (error) {
-    log(`Error checking for today's posts: ${error.message}`, 'WARN');
-    // Don't fail the entire sync if this check fails - just log and continue with publish
-    log(`Continuing with publish (unable to verify daily limit)`, 'INFO');
-    return false;
-  }
-}
-
-/**
- * Check if a post was published to Bluesky today
- *
- * Note: Uses time range from 00:00:00 UTC to current time (not 23:59:59 UTC like Micro.blog).
- * This is intentional: Bluesky has no scheduled posts, so we only check what's been posted so far today.
- * Micro.blog check uses full day to respect scheduled posts that may be for later today.
- *
- * @returns {Promise<boolean>} - True if a post was published today, false otherwise
- */
-async function checkBlueskyPostToday() {
-  const handle = process.env.BLUESKY_HANDLE;
-  const password = process.env.BLUESKY_PASSWORD;
-
-  if (!handle || !password) {
-    log(`Bluesky credentials not configured (BLUESKY_HANDLE, BLUESKY_PASSWORD) - skipping check`, 'DEBUG');
-    return false;
-  }
-
-  try {
-    const now = new Date();
-    const todayStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), 0, 0, 0));
-    const nowTime = now.getTime();
-    const todayStartTime = todayStart.getTime();
-
-    log(`Daily publish guard: Checking Bluesky for posts published today (${todayStart.toISOString().substring(0, 10)} UTC, up to now)`, 'DEBUG');
-
-    // Create agent and authenticate
-    const agent = new BskyAgent({
-      service: 'https://bsky.social'
-    });
-
-    await agent.login({
-      identifier: handle,
-      password: password
-    });
-
-    // Get user's recent posts (limit 10 to check quickly)
-    const response = await agent.getAuthorFeed({
-      actor: handle,
-      limit: 10
-    });
-
-    const posts = response.data.feed || [];
-
-    if (posts.length === 0) {
-      log(`No posts found on Bluesky`, 'INFO');
-      return false;
-    }
-
-    // Check if most recent top-level post (not a reply) is from today
-    for (const post of posts) {
-      const createdAt = post.post?.record?.createdAt;
-      const isReply = post.post?.record?.reply;  // Replies have a reply field
-
-      if (createdAt && !isReply) {  // Only count top-level posts, not replies
-        // Convert createdAt to numeric timestamp for consistent comparison
-        const createdTime = new Date(createdAt).getTime();
-        if (!Number.isFinite(createdTime)) {
-          log(`Invalid Bluesky post timestamp (${createdAt}) - skipping`, 'DEBUG');
-          continue;
-        }
-        // Check if posted from today's start up to now using numeric comparison
-        if (createdTime >= todayStartTime && createdTime <= nowTime) {
-          const postText = post.post?.record?.text?.substring(0, 50) || 'Untitled';
-          log(`✓ Already posted on Bluesky today: "${postText}" at ${createdAt}`, 'INFO');
-          log(`Daily publish guard: SKIPPING new post (max 1 per day)`, 'WARN');
-          return true;
-        }
-      }
-    }
-
-    // No posts from today found
-    log(`Most recent Bluesky post is from earlier (not today) - will publish`, 'INFO');
-    return false;
-  } catch (error) {
-    log(`Error checking Bluesky posts: ${error.message}`, 'WARN');
-    // Don't fail the entire sync if this check fails - just log and continue with publish
-    log(`Continuing with publish (unable to verify Bluesky daily limit)`, 'INFO');
-    return false;
-  }
 }
 
 /**
@@ -1301,27 +1135,6 @@ async function syncContent() {
       log(`  Remaining: ${totalUnpublished - 1} posts will publish over next ${totalUnpublished - 1} days`);
     } else {
       log(`\nFound ${rowsToPost.length} rows without Micro.blog URLs (need to be posted)`);
-    }
-
-    // ========================================================================
-    // Daily Publish Guard: Check if already posted today
-    // ========================================================================
-    // If a post has already been published to Micro.blog or Bluesky today (either
-    // manually or via automation), skip posting the next scheduled post to maintain
-    // max 1/day limit across all platforms
-    if (rowsToPost.length > 0) {
-      const [mbPostedToday, bskyPostedToday] = await Promise.all([
-        checkPublishedToday(),
-        checkBlueskyPostToday()
-      ]);
-
-      if (mbPostedToday || bskyPostedToday) {
-        const platforms = [];
-        if (mbPostedToday) platforms.push('Micro.blog');
-        if (bskyPostedToday) platforms.push('Bluesky');
-        log(`\nDaily limit reached: Already posted on ${platforms.join(' and ')}`, 'WARN');
-        rowsToPost.length = 0;  // Clear the array - don't post
-      }
     }
 
     // Track post creation statistics

--- a/src/sync-content.js
+++ b/src/sync-content.js
@@ -317,9 +317,12 @@ function log(message, level = 'INFO', data = null) {
  * @param {string} tabName - Tab name (e.g. "Sheet1" or "2024 & earlier")
  * @param {number} rowIndex - 1-based row index (matches spreadsheet row numbers)
  * @param {string} url - Micro.blog post URL from Location header, or '' to clear
+ * @param {boolean} [isNewPost=false] - Set true only for new post creation. URL repairs,
+ *   reconciliations, and clears must not set this flag, as they would mislead the social
+ *   posting guard into thinking career content was published today.
  * @returns {Promise<boolean>} - True if successful, false otherwise
  */
-async function writeUrlToSpreadsheet(sheets, spreadsheetId, tabName, rowIndex, url) {
+async function writeUrlToSpreadsheet(sheets, spreadsheetId, tabName, rowIndex, url, isNewPost = false) {
   try {
     if (DRY_RUN) {
       log(`[DRY-RUN] Would write URL to ${tabName} row ${rowIndex}: ${url || '(clear)'}`, 'INFO');
@@ -338,8 +341,8 @@ async function writeUrlToSpreadsheet(sheets, spreadsheetId, tabName, rowIndex, u
       )
     ];
 
-    // Write timestamp to Column I when setting a real URL (not when clearing)
-    if (url) {
+    // Write timestamp to Column I only for genuinely new posts, not repairs or clears
+    if (isNewPost && url) {
       const postedAt = new Date().toISOString();
       writes.push(
         withRetry(
@@ -1198,8 +1201,8 @@ async function syncContent() {
           );
           log(`  ✅ Social post created: ${socialUrl} (uncategorized, ephemeral)`, 'INFO');
 
-          // Only track archive post URL in Column H
-          const writeSuccess = await writeUrlToSpreadsheet(sheets, SPREADSHEET_ID, row.tabName, row.tabRowIndex, archiveUrl);
+          // Only track archive post URL in Column H; also marks today as a career post day
+          const writeSuccess = await writeUrlToSpreadsheet(sheets, SPREADSHEET_ID, row.tabName, row.tabRowIndex, archiveUrl, true);
 
           if (writeSuccess) {
             postStats.successful++;
@@ -1222,8 +1225,8 @@ async function syncContent() {
           );
           log(`✅ Post created: ${postUrl}`, 'INFO');
 
-          // Write URL to Column H
-          const writeSuccess = await writeUrlToSpreadsheet(sheets, SPREADSHEET_ID, row.tabName, row.tabRowIndex, postUrl);
+          // Write URL to Column H; also marks today as a career post day
+          const writeSuccess = await writeUrlToSpreadsheet(sheets, SPREADSHEET_ID, row.tabName, row.tabRowIndex, postUrl, true);
 
           if (writeSuccess) {
             postStats.successful++;

--- a/test/career-post-guard.test.js
+++ b/test/career-post-guard.test.js
@@ -10,10 +10,11 @@ const { checkCareerPostedToday } = require('../src/career-post-guard');
 
 const LIVE_SPREADSHEET_ID = '1E10fSvDbcDdtNNtDQ9QtydUXSBZH2znY6ztIxT4fwVs';
 
-function makeSheetsMock(colIValues) {
-  const mockGet = jest.fn().mockResolvedValue({
-    data: { values: colIValues },
-  });
+// Returns mockGet that responds with mainValues for Sheet1 and historicalValues for 2024 tab
+function makeSheetsMock(mainValues, historicalValues = []) {
+  const mockGet = jest.fn()
+    .mockResolvedValueOnce({ data: { values: mainValues } })
+    .mockResolvedValueOnce({ data: { values: historicalValues } });
   google.sheets.mockReturnValue({ spreadsheets: { values: { get: mockGet } } });
   google.auth = { GoogleAuth: jest.fn().mockImplementation(() => ({})) };
   return { mockGet };
@@ -65,13 +66,26 @@ describe('checkCareerPostedToday', () => {
     expect(result).toBe(false);
   });
 
-  test('reads from the correct spreadsheet and range (Sheet1!I:I)', async () => {
+  test('reads from both Sheet1!I:I and historical tab!I:I', async () => {
     const { mockGet } = makeSheetsMock([]);
     await checkCareerPostedToday();
     expect(mockGet).toHaveBeenCalledWith({
       spreadsheetId: LIVE_SPREADSHEET_ID,
       range: 'Sheet1!I:I',
     });
+    expect(mockGet).toHaveBeenCalledWith({
+      spreadsheetId: LIVE_SPREADSHEET_ID,
+      range: '2024 & earlier!I:I',
+    });
+  });
+
+  test('returns true when today timestamp is only in the historical tab', async () => {
+    makeSheetsMock(
+      [['2026-01-01T10:00:00.000Z']],                // Sheet1: old date
+      [[`${todayPrefix()}T16:00:00.000Z`]]            // historical: today (array of rows)
+    );
+    const result = await checkCareerPostedToday();
+    expect(result).toBe(true);
   });
 
   test('returns false (not throws) when GOOGLE_SERVICE_ACCOUNT_JSON is not set', async () => {
@@ -80,7 +94,7 @@ describe('checkCareerPostedToday', () => {
     expect(result).toBe(false);
   });
 
-  test('returns false (not throws) when the Sheets API call fails', async () => {
+  test('returns false (not throws) when a Sheets API call fails', async () => {
     google.sheets.mockReturnValue({
       spreadsheets: { values: { get: jest.fn().mockRejectedValue(new Error('Network error')) } },
     });

--- a/test/career-post-guard.test.js
+++ b/test/career-post-guard.test.js
@@ -1,0 +1,91 @@
+// ABOUTME: Tests for career-post-guard — checks whether career content was posted today.
+// ABOUTME: Verifies spreadsheet-based daily guard logic used by post-social-content.js.
+
+'use strict';
+
+jest.mock('googleapis');
+
+const { google } = require('googleapis');
+const { checkCareerPostedToday } = require('../src/career-post-guard');
+
+const LIVE_SPREADSHEET_ID = '1E10fSvDbcDdtNNtDQ9QtydUXSBZH2znY6ztIxT4fwVs';
+
+function makeSheetsMock(colIValues) {
+  const mockGet = jest.fn().mockResolvedValue({
+    data: { values: colIValues },
+  });
+  google.sheets.mockReturnValue({ spreadsheets: { values: { get: mockGet } } });
+  google.auth = { GoogleAuth: jest.fn().mockImplementation(() => ({})) };
+  return { mockGet };
+}
+
+function todayPrefix() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+describe('checkCareerPostedToday', () => {
+  beforeEach(() => {
+    process.env.GOOGLE_SERVICE_ACCOUNT_JSON = JSON.stringify({ type: 'service_account' });
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+    jest.clearAllMocks();
+  });
+
+  test('returns true when a row has a timestamp from today', async () => {
+    makeSheetsMock([
+      ['Micro.blog Posted At'],
+      ['2026-01-15T10:00:00.000Z'],
+      [`${todayPrefix()}T16:15:00.000Z`],
+    ]);
+    const result = await checkCareerPostedToday();
+    expect(result).toBe(true);
+  });
+
+  test('returns false when all Column I timestamps are from earlier dates', async () => {
+    makeSheetsMock([
+      ['Micro.blog Posted At'],
+      ['2026-01-15T10:00:00.000Z'],
+      ['2026-03-01T12:00:00.000Z'],
+    ]);
+    const result = await checkCareerPostedToday();
+    expect(result).toBe(false);
+  });
+
+  test('returns false when Column I is empty', async () => {
+    makeSheetsMock([]);
+    const result = await checkCareerPostedToday();
+    expect(result).toBe(false);
+  });
+
+  test('returns false when all Column I cells are empty strings', async () => {
+    makeSheetsMock([[''], [''], ['']]);
+    const result = await checkCareerPostedToday();
+    expect(result).toBe(false);
+  });
+
+  test('reads from the correct spreadsheet and range (Sheet1!I:I)', async () => {
+    const { mockGet } = makeSheetsMock([]);
+    await checkCareerPostedToday();
+    expect(mockGet).toHaveBeenCalledWith({
+      spreadsheetId: LIVE_SPREADSHEET_ID,
+      range: 'Sheet1!I:I',
+    });
+  });
+
+  test('returns false (not throws) when GOOGLE_SERVICE_ACCOUNT_JSON is not set', async () => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+    const result = await checkCareerPostedToday();
+    expect(result).toBe(false);
+  });
+
+  test('returns false (not throws) when the Sheets API call fails', async () => {
+    google.sheets.mockReturnValue({
+      spreadsheets: { values: { get: jest.fn().mockRejectedValue(new Error('Network error')) } },
+    });
+    google.auth = { GoogleAuth: jest.fn().mockImplementation(() => ({})) };
+    const result = await checkCareerPostedToday();
+    expect(result).toBe(false);
+  });
+});

--- a/test/post-social-content.test.js
+++ b/test/post-social-content.test.js
@@ -4,6 +4,7 @@
 'use strict';
 
 jest.mock('../src/social-posts-queue');
+jest.mock('../src/career-post-guard');
 jest.mock('../src/post-bluesky');
 // post-mastodon loads masto which has ESM-only transitive deps — use manual factory
 jest.mock('../src/post-mastodon', () => ({
@@ -16,6 +17,7 @@ jest.mock('../src/post-microblog', () => ({
 jest.mock('../src/update-social-post-status');
 
 const { fetchPendingPostsForToday } = require('../src/social-posts-queue');
+const { checkCareerPostedToday } = require('../src/career-post-guard');
 const { postToBluesky } = require('../src/post-bluesky');
 const { postToMastodon } = require('../src/post-mastodon');
 const { postToLinkedIn } = require('../src/post-linkedin');
@@ -48,6 +50,7 @@ const TODAY = '2026-04-05';
 describe('processPostsForDate', () => {
   beforeEach(() => {
     fetchPendingPostsForToday.mockResolvedValue([]);
+    checkCareerPostedToday.mockResolvedValue(false);
     postToBluesky.mockResolvedValue({ postUrl: 'https://bsky.app/profile/handle/post/abc' });
     postToMastodon.mockResolvedValue({ postUrl: 'https://mastodon.social/@whitney/109375123456789012' });
     postToLinkedIn.mockResolvedValue({ postUrl: 'https://www.linkedin.com/feed/update/urn:li:share:123/' });
@@ -234,6 +237,29 @@ describe('processPostsForDate', () => {
     expect(postToBluesky).toHaveBeenCalledWith(post);
     expect(postToMastodon).toHaveBeenCalledWith(post);
     expect(postToLinkedIn).toHaveBeenCalledWith(post);
+  });
+
+  test('skips all platform dispatch when career content was posted today', async () => {
+    checkCareerPostedToday.mockResolvedValue(true);
+    const post = makePost({ platforms: ['bluesky', 'mastodon', 'linkedin'] });
+    fetchPendingPostsForToday.mockResolvedValue([post]);
+
+    await processPostsForDate(TODAY);
+
+    expect(postToBluesky).not.toHaveBeenCalled();
+    expect(postToMastodon).not.toHaveBeenCalled();
+    expect(postToLinkedIn).not.toHaveBeenCalled();
+    expect(updatePostResult).not.toHaveBeenCalled();
+  });
+
+  test('proceeds normally when career has not posted today', async () => {
+    checkCareerPostedToday.mockResolvedValue(false);
+    const post = makePost({ platforms: ['bluesky'] });
+    fetchPendingPostsForToday.mockResolvedValue([post]);
+
+    await processPostsForDate(TODAY);
+
+    expect(postToBluesky).toHaveBeenCalledWith(post);
   });
 
   test('writes single aggregated result with all URLs when all three platforms succeed', async () => {


### PR DESCRIPTION
## Summary

Fixes the broken daily publish guard in `sync-content.js` that used Bluesky and Micro.blog as proxies for "did the system post today?" — both proxies incorrectly fired on personal posts Whitney makes directly in the Micro.blog UI.

- Remove `checkPublishedToday()` and `checkBlueskyPostToday()` from `sync-content.js`
- Add Column I ("Micro.blog Posted At") ISO timestamp to the live spreadsheet whenever `writeUrlToSpreadsheet()` posts a career item
- New `src/career-post-guard.js` reads Column I from the live spreadsheet to check if career content posted today; returns false on any error so the guard never blocks unexpectedly
- `post-social-content.js` now calls `checkCareerPostedToday()` before dispatching — social defers to career (career > social priority, one managed post per day)
- Remove `BLUESKY_HANDLE`/`BLUESKY_PASSWORD` from the sync step in `daily-sync.yml` — no longer needed
- Extend spreadsheet `RANGE` from `A:H` to `A:I`

Personal posts (made via Micro.blog UI) are automatically exempt because they never touch the live spreadsheet.

## Test plan

- [ ] 120 unit tests passing
- [ ] Acceptance gate (`npm run check-secrets`) verifies secrets accessible from GSM
- [ ] `career-post-guard.test.js` — 7 tests covering today/past/empty/error cases and correct spreadsheet range
- [ ] `post-social-content.test.js` — new tests verify social dispatch skips when career posted today and proceeds when not

## Related issues

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced post-type taxonomy with three categories: career, social, and personal posts, each with distinct scheduling rules.
  * Implemented daily posting limits: maximum of one managed post per day across career and social posts (personal posts exempt).
  * Applied priority ordering: career posts take precedence; social posts defer if career content already published that day.
  * Added posting timestamp tracking to enforce daily scheduling limits.

* **Chores**
  * Updated workflow configuration for enhanced credential management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->