### PR TITLE
feat(#29): wire micro.blog episode dispatch into daily social cron

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -28,3 +28,4 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 - (2026-04-07) Added fetchRecentShortRows to social-posts-queue and updateMicroblogPostUrl to update-social-post-status; wired micro.blog scan into post-social-content.js cron (PRD #22, Milestone 6)
 - (2026-04-07) Added AnimMouse/setup-yt-dlp@v3 to daily-sync.yml and fixed Post social content step secrets; 111 tests passing (PRD #22, Milestone 6)
 - (2026-04-07) Fixed yt-dlp format selector to prefer pre-merged MP4 (no ffmpeg needed locally); verified live post to micro.blog plays correctly (PRD #22, Milestone 6)
+- (2026-04-24) Wired micro.blog episode post dispatch into the daily social cron: `dispatchPost()` now handles `platforms = micro.blog` rows by calling `postToMicroblog()` with view-count check bypassed. Scheduled episode posts launch on their scheduled date rather than waiting for the 1,000-view threshold. The threshold-gated short scan (`scanAndPostShorts`) is unchanged.

--- a/src/post-microblog.js
+++ b/src/post-microblog.js
@@ -205,17 +205,19 @@ async function createMicropubPost(postText, mediaUrl, mimeType, altText, token) 
  * @param {Object} post - Post object from the social posts queue
  * @returns {Promise<{postUrl: string}|{skipped: true, viewCount: number}>}
  */
-async function postToMicroblog(post) {
+async function postToMicroblog(post, { bypassViewCount = false } = {}) {
   const token = process.env.MICROBLOG_APP_TOKEN;
   if (!token) throw new Error('MICROBLOG_APP_TOKEN environment variable is required');
 
   const videoId = extractYouTubeVideoId(post.youtubeUrl);
   if (!videoId) throw new Error(`Could not extract video ID from: ${post.youtubeUrl}`);
 
-  const viewCount = await getYouTubeViewCount(videoId);
-  if (viewCount < VIEW_COUNT_THRESHOLD) {
-    console.log(`[microblog] Row ${post.rowIndex}: ${viewCount} views < ${VIEW_COUNT_THRESHOLD} threshold, skipping`); // eslint-disable-line no-console
-    return { skipped: true, viewCount };
+  if (!bypassViewCount) {
+    const viewCount = await getYouTubeViewCount(videoId);
+    if (viewCount < VIEW_COUNT_THRESHOLD) {
+      console.log(`[microblog] Row ${post.rowIndex}: ${viewCount} views < ${VIEW_COUNT_THRESHOLD} threshold, skipping`); // eslint-disable-line no-console
+      return { skipped: true, viewCount };
+    }
   }
 
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'microblog-'));

--- a/src/post-social-content.js
+++ b/src/post-social-content.js
@@ -61,7 +61,7 @@ async function dispatchPost(post) {
     }
   }
 
-  if (post.platforms.includes('micro.blog')) {
+  if (post.platforms.includes('micro.blog') && post.postType !== 'short') {
     attemptCount++;
     try {
       ({ postUrl: microblogPostUrl } = await postToMicroblog(post, { bypassViewCount: true }));

--- a/src/post-social-content.js
+++ b/src/post-social-content.js
@@ -8,7 +8,7 @@ const { checkCareerPostedToday } = require('./career-post-guard');
 const { postToBluesky } = require('./post-bluesky');
 const { postToMastodon } = require('./post-mastodon');
 const { postToLinkedIn } = require('./post-linkedin');
-const { scanAndPostShorts } = require('./post-microblog');
+const { scanAndPostShorts, postToMicroblog } = require('./post-microblog');
 const { updatePostResult } = require('./update-social-post-status');
 
 function getTodayDate() {
@@ -26,7 +26,7 @@ function getTodayDate() {
 async function dispatchPost(post) {
   let failureCount = 0;
   let attemptCount = 0;
-  let bskyPostUrl, mastodonPostUrl, linkedinPostUrl;
+  let bskyPostUrl, mastodonPostUrl, linkedinPostUrl, microblogPostUrl;
 
   if (post.platforms.includes('bluesky')) {
     attemptCount++;
@@ -61,6 +61,17 @@ async function dispatchPost(post) {
     }
   }
 
+  if (post.platforms.includes('micro.blog')) {
+    attemptCount++;
+    try {
+      ({ postUrl: microblogPostUrl } = await postToMicroblog(post, { bypassViewCount: true }));
+      console.log(`[social] Posted row ${post.rowIndex} to micro.blog: ${microblogPostUrl}`); // eslint-disable-line no-console
+    } catch (err) {
+      console.error(`[social] Failed to post row ${post.rowIndex} to micro.blog: ${err.message}`); // eslint-disable-line no-console
+      failureCount++;
+    }
+  }
+
   if (attemptCount === 0) return;
 
   const status = failureCount === 0 ? 'posted' : 'failed';
@@ -68,6 +79,7 @@ async function dispatchPost(post) {
   if (bskyPostUrl) resultFields.bskyPostUrl = bskyPostUrl;
   if (mastodonPostUrl) resultFields.mastodonPostUrl = mastodonPostUrl;
   if (linkedinPostUrl) resultFields.linkedinPostUrl = linkedinPostUrl;
+  if (microblogPostUrl) resultFields.microblogPostUrl = microblogPostUrl;
 
   await updatePostResult(post.rowIndex, resultFields);
 }

--- a/src/post-social-content.js
+++ b/src/post-social-content.js
@@ -11,6 +11,11 @@ const { postToLinkedIn } = require('./post-linkedin');
 const { scanAndPostShorts, postToMicroblog } = require('./post-microblog');
 const { updatePostResult } = require('./update-social-post-status');
 
+/**
+ * Return today's date as a YYYY-MM-DD string in UTC.
+ *
+ * @returns {string}
+ */
 function getTodayDate() {
   return new Date().toISOString().slice(0, 10); // YYYY-MM-DD
 }
@@ -112,6 +117,9 @@ async function processPostsForDate(today) {
   }
 }
 
+/**
+ * Entry point: read today's date, run the social post queue, then run the micro.blog short scan.
+ */
 async function main() {
   const today = getTodayDate();
   console.log(`[social] Checking queue for posts due ${today}`); // eslint-disable-line no-console

--- a/test/post-social-content.test.js
+++ b/test/post-social-content.test.js
@@ -13,6 +13,7 @@ jest.mock('../src/post-mastodon', () => ({
 jest.mock('../src/post-linkedin');
 jest.mock('../src/post-microblog', () => ({
   scanAndPostShorts: jest.fn(),
+  postToMicroblog: jest.fn(),
 }));
 jest.mock('../src/update-social-post-status');
 
@@ -21,7 +22,7 @@ const { checkCareerPostedToday } = require('../src/career-post-guard');
 const { postToBluesky } = require('../src/post-bluesky');
 const { postToMastodon } = require('../src/post-mastodon');
 const { postToLinkedIn } = require('../src/post-linkedin');
-const { scanAndPostShorts } = require('../src/post-microblog');
+const { scanAndPostShorts, postToMicroblog } = require('../src/post-microblog');
 const { updatePostResult } = require('../src/update-social-post-status');
 const { processPostsForDate } = require('../src/post-social-content');
 
@@ -54,6 +55,7 @@ describe('processPostsForDate', () => {
     postToBluesky.mockResolvedValue({ postUrl: 'https://bsky.app/profile/handle/post/abc' });
     postToMastodon.mockResolvedValue({ postUrl: 'https://mastodon.social/@whitney/109375123456789012' });
     postToLinkedIn.mockResolvedValue({ postUrl: 'https://www.linkedin.com/feed/update/urn:li:share:123/' });
+    postToMicroblog.mockResolvedValue({ postUrl: 'https://whitneylee.com/2026/04/test-episode' });
     scanAndPostShorts.mockResolvedValue(undefined);
     updatePostResult.mockResolvedValue(undefined);
   });
@@ -292,6 +294,63 @@ describe('processPostsForDate', () => {
     expect(updatePostResult).toHaveBeenCalledWith(11, {
       status: 'failed',
       bskyPostUrl: 'https://bsky.app/profile/handle/post/ccc',
+    });
+  });
+
+  test('posts to micro.blog for a pending row with micro.blog platform', async () => {
+    const post = makePost({ platforms: ['micro.blog'] });
+    fetchPendingPostsForToday.mockResolvedValue([post]);
+
+    await processPostsForDate(TODAY);
+
+    expect(postToMicroblog).toHaveBeenCalledWith(post, { bypassViewCount: true });
+  });
+
+  test('updates sheet with posted status and micro.blog URL on success', async () => {
+    const post = makePost({ rowIndex: 12, platforms: ['micro.blog'] });
+    fetchPendingPostsForToday.mockResolvedValue([post]);
+    postToMicroblog.mockResolvedValue({ postUrl: 'https://whitneylee.com/2026/04/my-episode' });
+
+    await processPostsForDate(TODAY);
+
+    expect(updatePostResult).toHaveBeenCalledWith(12, {
+      status: 'posted',
+      microblogPostUrl: 'https://whitneylee.com/2026/04/my-episode',
+    });
+  });
+
+  test('skips micro.blog posting for rows without micro.blog platform', async () => {
+    const post = makePost({ platforms: ['bluesky'] });
+    fetchPendingPostsForToday.mockResolvedValue([post]);
+
+    await processPostsForDate(TODAY);
+
+    expect(postToMicroblog).not.toHaveBeenCalled();
+  });
+
+  test('writes failed status and logs on micro.blog post failure without crashing', async () => {
+    const post = makePost({ rowIndex: 13, platforms: ['micro.blog'] });
+    fetchPendingPostsForToday.mockResolvedValue([post]);
+    postToMicroblog.mockRejectedValue(new Error('Micropub API error'));
+
+    await expect(processPostsForDate(TODAY)).resolves.not.toThrow();
+
+    expect(updatePostResult).toHaveBeenCalledWith(13, { status: 'failed' });
+  });
+
+  test('includes micro.blog URL in aggregated result alongside other platforms', async () => {
+    const post = makePost({ rowIndex: 14, platforms: ['bluesky', 'micro.blog'] });
+    fetchPendingPostsForToday.mockResolvedValue([post]);
+    postToBluesky.mockResolvedValue({ postUrl: 'https://bsky.app/profile/handle/post/ddd' });
+    postToMicroblog.mockResolvedValue({ postUrl: 'https://whitneylee.com/2026/04/multi-platform' });
+
+    await processPostsForDate(TODAY);
+
+    expect(updatePostResult).toHaveBeenCalledTimes(1);
+    expect(updatePostResult).toHaveBeenCalledWith(14, {
+      status: 'posted',
+      bskyPostUrl: 'https://bsky.app/profile/handle/post/ddd',
+      microblogPostUrl: 'https://whitneylee.com/2026/04/multi-platform',
     });
   });
 });

--- a/test/post-social-content.test.js
+++ b/test/post-social-content.test.js
@@ -338,6 +338,16 @@ describe('processPostsForDate', () => {
     expect(updatePostResult).toHaveBeenCalledWith(13, { status: 'failed' });
   });
 
+  test('does not dispatch to micro.blog for short rows — shorts remain threshold-gated via scanAndPostShorts', async () => {
+    const post = makePost({ rowIndex: 15, postType: 'short', platforms: ['micro.blog'] });
+    fetchPendingPostsForToday.mockResolvedValue([post]);
+
+    await processPostsForDate(TODAY);
+
+    expect(postToMicroblog).not.toHaveBeenCalled();
+    expect(updatePostResult).not.toHaveBeenCalled();
+  });
+
   test('includes micro.blog URL in aggregated result alongside other platforms', async () => {
     const post = makePost({ rowIndex: 14, platforms: ['bluesky', 'micro.blog'] });
     fetchPendingPostsForToday.mockResolvedValue([post]);


### PR DESCRIPTION
## Summary

- Adds `micro.blog` as a dispatchable platform in `dispatchPost()` in `post-social-content.js`
- Calls `postToMicroblog(post, { bypassViewCount: true })` for rows with `platforms = micro.blog`, so scheduled episode posts go out on their date without waiting for the 1,000-view threshold
- Adds `bypassViewCount` option to `postToMicroblog()` in `post-microblog.js` — when true, skips the YouTube view count check entirely
- The threshold-gated short scan (`scanAndPostShorts`) behavior is unchanged

## Test plan

- [x] 5 new tests in `test/post-social-content.test.js` covering: dispatch call with `bypassViewCount: true`, sheet update with micro.blog URL, skip when platform not listed, failure handling, and multi-platform aggregation
- [x] All 126 tests pass
- [x] Pre-push security check passed

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Micro.blog posts now publish without waiting for view-count thresholds; episode posts go live on their scheduled date.
  * Posting results now include the micro.blog post URL alongside other platform URLs.

* **Tests**
  * Added coverage for micro.blog dispatch, success/failure handling, and ensuring short-form posts remain threshold-gated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->