### PR TITLE
fix: add missing career-guard log for no-post-today case

### DIFF
--- a/src/career-post-guard.js
+++ b/src/career-post-guard.js
@@ -64,6 +64,8 @@ async function checkCareerPostedToday() {
 
     if (posted) {
       console.log(`[career-guard] Career content already posted today (${today}) — skipping social dispatch`); // eslint-disable-line no-console
+    } else {
+      console.log(`[career-guard] No career content posted today (${today})`); // eslint-disable-line no-console
     }
     return posted;
   } catch (err) {


### PR DESCRIPTION
## Summary

- `checkCareerPostedToday()` only logged in the "career already posted" branch, leaving the "not posted today" case silent
- The e2e test asserts `[career-guard]` appears in output; when the non-micro.blog queue is non-empty, `fetchOldestPendingGroup()` returns posts and exits early — `checkAllCareerPostsPublished()` is never reached, so that `[career-guard]` path is skipped too
- The only remaining `checkCareerPostedToday()` call (line 198, pre-short-scan) returned silently on the happy path, breaking the e2e assertion

Root cause: the test has been failing since 2026-04-28 because social posts were added to the queue after the feature merged on 2026-04-27. On 2026-04-27 the queue was empty, so the backlog-check path was reached and happened to produce a `[career-guard]` log.

Fix: add the else branch so the function always logs when it completes successfully.

## Test plan

- [x] `npm run test:e2e` — all 3 tests pass locally
- [x] Review the change in context: the new log appears at the pre-short-scan call site (`main()` line 198), which always runs after `processPostsForDate()` completes
- [ ] Update `PROGRESS.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging to provide visibility into daily career content posting status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->