### PR TITLE
fix: escape reserved characters in LinkedIn commentary field

### DIFF
--- a/src/post-linkedin.js
+++ b/src/post-linkedin.js
@@ -8,6 +8,15 @@ const LINKEDIN_API_BASE = 'https://api.linkedin.com';
 const LINKEDIN_VERSION = '202603';
 const WARNING_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
+// LinkedIn's `little` text format reserves 13 characters that must be backslash-escaped.
+// Unescaped reserved chars silently drop all following text — API still returns 201.
+// See .claude/rules/linkedin-api-gotchas.md for full details.
+const LINKEDIN_RESERVED_CHARS = /[()[\]{}\@#*_~<>\\]/g;
+
+function escapeLinkedInCommentary(text) {
+  return text.replace(LINKEDIN_RESERVED_CHARS, '\\$&');
+}
+
 /**
  * Build a LinkedIn web URL from a post URN returned in the x-restli-id header.
  *
@@ -223,7 +232,7 @@ async function postToLinkedIn(post, { videoBuffer, imageBuffer } = {}) {
 
   const body = {
     author: personUrn,
-    commentary: post.postText,
+    commentary: escapeLinkedInCommentary(post.postText),
     visibility: 'PUBLIC',
     distribution: {
       feedDistribution: 'MAIN_FEED',

--- a/test/post-linkedin.test.js
+++ b/test/post-linkedin.test.js
@@ -176,12 +176,12 @@ describe('postToLinkedIn', () => {
       expect(body.content).toBeUndefined();
     });
 
-    test('escapes reserved little-text characters in commentary', async () => {
+    test('escapes all 13 reserved little-text characters in commentary', async () => {
       mockSuccess();
-      const post = makePost({ postText: 'Cluster (service maps, application traffic) → https://youtu.be/abc #Kubernetes' });
+      const post = makePost({ postText: '()[]{}@#*_~<>\\' });
       await postToLinkedIn(post);
       const body = JSON.parse(global.fetch.mock.calls[0][1].body);
-      expect(body.commentary).toBe('Cluster \\(service maps, application traffic\\) → https://youtu.be/abc \\#Kubernetes');
+      expect(body.commentary).toBe('\\(\\)\\[\\]\\{\\}\\@\\#\\*\\_\\~\\<\\>\\\\');
     });
   });
 

--- a/test/post-linkedin.test.js
+++ b/test/post-linkedin.test.js
@@ -175,6 +175,14 @@ describe('postToLinkedIn', () => {
       const body = JSON.parse(global.fetch.mock.calls[0][1].body);
       expect(body.content).toBeUndefined();
     });
+
+    test('escapes reserved little-text characters in commentary', async () => {
+      mockSuccess();
+      const post = makePost({ postText: 'Cluster (service maps, application traffic) → https://youtu.be/abc #Kubernetes' });
+      await postToLinkedIn(post);
+      const body = JSON.parse(global.fetch.mock.calls[0][1].body);
+      expect(body.commentary).toBe('Cluster \\(service maps, application traffic\\) → https://youtu.be/abc \\#Kubernetes');
+    });
   });
 
   describe('image path (imageBuffer provided)', () => {


### PR DESCRIPTION
## Problem

LinkedIn's `little` text format silently truncates `commentary` at the first unescaped reserved character. The API still returns 201 and the full text is stored on LinkedIn's servers — but the rendered post shows only the text before the first reserved character, with no "see more" link.

The 13 reserved characters are: `( ) [ ] { } @ # * _ ~ < > \`

Episode posts commonly contain parentheses (e.g., `(service maps, application traffic)`), so the first sentence was all that ever rendered for image/video posts.

Verified live: deleted and reposted the Pixie Thunder episode with escaped text — full multi-paragraph post rendered correctly with image attached.

## Fix

Added `escapeLinkedInCommentary()` and applied it to the `commentary` field for all LinkedIn post types.

## Test plan

- [ ] New test: escapes all reserved characters correctly
- [ ] 318 unit tests pass
- [ ] Existing LinkedIn post text with parentheses renders fully on LinkedIn

Closes no issue — this was discovered during live testing of #48.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LinkedIn post text handling: special characters (parentheses, hashtags, and other reserved symbols) are now escaped before submission, preventing formatting issues and ensuring posts display correctly.

* **Tests**
  * Added test coverage confirming special characters in LinkedIn post text are properly escaped during submission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->