### PR TITLE
fix(sync): remove historical tab from daily sync spreadsheet read

### DIFF
--- a/src/sync-content.js
+++ b/src/sync-content.js
@@ -1035,11 +1035,9 @@ async function syncContent() {
 
     const sheets = google.sheets({ version: 'v4', auth });
 
-    // Read spreadsheet data with retry logic from multiple tabs
+    // Read spreadsheet data — Sheet1 only
+    // The "2024 & earlier" historical tab is managed by sync-historical-posts.js, not the daily sync.
     log(`Reading spreadsheet: ${SPREADSHEET_ID}`);
-
-    // Read current content from Sheet1
-    log(`  Reading Sheet1...`);
     const sheet1Response = await withRetry(
       () => sheets.spreadsheets.values.get({
         spreadsheetId: SPREADSHEET_ID,
@@ -1048,43 +1046,14 @@ async function syncContent() {
       'Read Sheet1'
     );
     const sheet1Rows = sheet1Response.data.values || [];
-    log(`  Found ${sheet1Rows.length} rows in Sheet1`);
+    log(`Found ${sheet1Rows.length} rows in Sheet1\n`);
 
-    // Read historical content
-    log(`  Reading ${HISTORICAL_TAB_NAME}...`);
-    const historicalResponse = await withRetry(
-      () => sheets.spreadsheets.values.get({
-        spreadsheetId: SPREADSHEET_ID,
-        range: `${HISTORICAL_TAB_NAME}!A:H`,
-      }),
-      `Read ${HISTORICAL_TAB_NAME}`
-    );
-    const historicalRows = historicalResponse.data.values || [];
-    log(`  Found ${historicalRows.length} rows in ${HISTORICAL_TAB_NAME}`);
-
-    // Combine rows with tab tracking
-    // Each item: { row: [...], tabName: 'Sheet1' | '2024 & earlier', tabRowIndex: N }
-    const rowsWithMetadata = [];
-
-    // Add Sheet1 rows (including header row for parsing, will be skipped during validation)
-    sheet1Rows.forEach((row, idx) => {
-      rowsWithMetadata.push({
-        row: row,
-        tabName: SHEET_NAME,
-        tabRowIndex: idx + 1  // Google Sheets is 1-indexed (row 1 = header, row 2 = first data)
-      });
-    });
-
-    // Add historical rows (including header row for parsing, will be skipped during validation)
-    historicalRows.forEach((row, idx) => {
-      rowsWithMetadata.push({
-        row: row,
-        tabName: HISTORICAL_TAB_NAME,
-        tabRowIndex: idx + 1  // Google Sheets is 1-indexed (row 1 = header, row 2 = first data)
-      });
-    });
-
-    log(`Found ${rowsWithMetadata.length} total rows (including header)\n`);
+    // Each item: { row: [...], tabName: 'Sheet1', tabRowIndex: N }
+    const rowsWithMetadata = sheet1Rows.map((row, idx) => ({
+      row,
+      tabName: SHEET_NAME,
+      tabRowIndex: idx + 1,  // Google Sheets is 1-indexed (row 1 = header, row 2 = first data)
+    }));
 
     // Parse and validate rows
     const validRows = [];


### PR DESCRIPTION
## What happened

`sync-content.js` was reading both `Sheet1` and the `2024 & earlier` historical tab on every daily sync run. This was introduced in PRD-53 to support `writeUrlToSpreadsheet` knowing which tab to write back to — but it inadvertently pulled 289 historical rows (already synced by `sync-historical-posts.js`) into the daily processing loop.

## Impact

- **May 18**: The URL regeneration logic found ~hundreds of 2022-2024 posts with "non-title" slugs and tried to delete/recreate all of them. Hit micro.blog's rate limit with 403 errors. Run failed.
- **May 19**: Run succeeded but picked up one row from `2024 & earlier` (IBM Cloud etcd, 2020-08-25) as "unposted" and created a social post dated today, which cross-posted to LinkedIn/Bluesky/Mastodon.

## Fix

Daily sync now reads `Sheet1` only. The `2024 & earlier` tab is managed exclusively by `sync-historical-posts.js` (the one-time historical backfill script).

## Cleanup needed (separate from this PR)

- Delete the erroneous May 19 micro.blog social post `https://whitneylee.com/2026/05/19/ibm-cloud-what-is-etcd.html`
- Verify the two spreadsheet rows that had their URLs cleared by the May 19 URL regeneration step are restored

Closes #62 (if tracked)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified data synchronization to read only current sheet data instead of combining current and historical sheets, simplifying the ingestion process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/content-manager/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->