### PR TITLE
fix(sync): strip img tags from existing content before change detection

### DIFF
--- a/src/sync-content.js
+++ b/src/sync-content.js
@@ -766,7 +766,11 @@ function detectChanges(row, existingPost) {
   // Generate expected content (includes title, show, keynote)
   const expectedContent = formatPostContent(row);
   const contentNormalized = normalizeWhitespace(expectedContent);
-  const existingContentNormalized = normalizeWhitespace(existingPost.content);
+  // Strip <img> tags before comparing — backfill scripts append images to post
+  // content and they must not trigger false "title changed" URL regeneration.
+  const existingContentNormalized = normalizeWhitespace(
+    (existingPost.content || '').replace(/<img[^>]*>/g, '').trimEnd()
+  );
 
   if (contentNormalized !== existingContentNormalized) {
     changes.content = expectedContent;

--- a/tests/sync-content.test.js
+++ b/tests/sync-content.test.js
@@ -1,7 +1,7 @@
-// ABOUTME: Unit tests for sync-content.js — covers parseRow highlight column parsing, needsImage logic, and runAboutPageUpdate integration.
+// ABOUTME: Unit tests for sync-content.js — covers parseRow highlight column parsing, needsImage logic, detectChanges, and runAboutPageUpdate integration.
 'use strict';
 
-const { parseRow, runAboutPageUpdate, needsImage } = require('../src/sync-content');
+const { parseRow, runAboutPageUpdate, needsImage, detectChanges } = require('../src/sync-content');
 
 // Minimal valid row fixture (columns A-I, no highlight columns)
 function makeRow({ name = 'Test Talk', type = 'Podcast', show = 'SDI', date = '1/1/2026',
@@ -165,5 +165,34 @@ describe('runAboutPageUpdate', () => {
     const mockUpdate = jest.fn().mockResolvedValue({ updated: false });
     await runAboutPageUpdate([], { updateFn: mockUpdate });
     expect(mockUpdate).toHaveBeenCalledWith([], expect.any(Date));
+  });
+});
+
+describe('detectChanges', () => {
+  const baseRow = { name: 'My Talk', type: 'Video', show: '🌩️ Thunder', date: '4/23/2026',
+    confirmed: '', link: 'https://youtu.be/abc' };
+
+  function makePost(content, { category = 'Video', published = '2026-04-23T00:00:00Z' } = {}) {
+    return { content, category, published };
+  }
+
+  test('returns no changes when content matches exactly', () => {
+    const existingContent = '🌩️ Thunder: [My Talk](https://youtu.be/abc)';
+    const { needsUpdate, needsRegeneration } = detectChanges(baseRow,
+      makePost(existingContent));
+    expect(needsRegeneration).toBe(false);
+  });
+
+  test('does not flag needsRegeneration when only an img tag was added by backfill', () => {
+    const baseContent = '🌩️ Thunder: [My Talk](https://youtu.be/abc)';
+    const withImage = baseContent + '\n\n<img src="https://whitneylee.com/uploads/thumb.jpg" width="600">';
+    const { needsRegeneration } = detectChanges(baseRow, makePost(withImage));
+    expect(needsRegeneration).toBe(false);
+  });
+
+  test('still detects genuine title change even when img tag present', () => {
+    const oldContent = '🌩️ Thunder: [Old Title](https://youtu.be/abc)\n\n<img src="https://whitneylee.com/uploads/thumb.jpg">';
+    const { needsRegeneration } = detectChanges(baseRow, makePost(oldContent));
+    expect(needsRegeneration).toBe(true);
   });
 });


### PR DESCRIPTION
## What broke

`detectChanges` compared `formatPostContent(row)` (which contains no `<img>` tag) against the actual post content in micro.blog (which has `<img>` tags appended by the backfill scripts from PRD-53). Any mismatch was flagged as "title or show changed" → URL regeneration → **delete the existing post and recreate it**.

Every post that received a backfill image was scheduled for deletion on the next daily sync run. The May 18 run deleted 299 posts before hitting micro.blog's rate limit.

## The fix

Strip `<img>` tags from `existingPost.content` before comparing in `detectChanges`. Backfill-added images are invisible to the title/show/keynote change detector. URL regeneration still fires correctly for genuine title, show, keynote, and date changes.

## Tests added

Three new `detectChanges` tests in `tests/sync-content.test.js`:
- No changes when content matches exactly
- No regeneration when only a backfill `<img>` tag differs
- Regeneration still fires when title genuinely changed (even with `<img>` present)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed content change detection to properly handle image elements automatically added to posts.

* **Tests**
  * Added test coverage for content change detection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->