### PR TITLE
fix(sync-historical): add delay between Micropub post creation calls

### DIFF
--- a/src/sync-historical-posts.js
+++ b/src/sync-historical-posts.js
@@ -29,6 +29,10 @@ const DRY_RUN = process.argv.includes('--dry-run');
 
 // Google Sheets write rate limit: 60 writes/min; 1500ms = 40/min with buffer
 const SHEETS_WRITE_DELAY_MS = 1500;
+// Micropub rate limit: pause between post creation calls to avoid silent rejection
+// micro.blog silently accepts bulk requests (202) but drops posts if too many arrive
+// in quick succession. 3s between calls = ~20 posts/min, well within safe limits.
+const MICROPUB_DELAY_MS = 3000;
 
 /**
  * Filter rows to those that have never been synced to micro.blog and have a
@@ -158,6 +162,9 @@ async function syncHistoricalPosts() {
       stats.failed++;
       continue;
     }
+
+    // Pause between Micropub calls — micro.blog silently drops posts under rapid bulk creation
+    await new Promise(r => setTimeout(r, MICROPUB_DELAY_MS));
 
     // Write URL back to column H (isNewPost=false: don't write timestamp to column I —
     // timestamps are used by the daily sync guard to detect whether career content ran today)

--- a/src/sync-historical-posts.js
+++ b/src/sync-historical-posts.js
@@ -151,7 +151,8 @@ async function syncHistoricalPosts() {
       }
     }
 
-    // Create the archive post
+    // Create the archive post — pause after every attempt (success or failure) to
+    // respect micro.blog's rate limit on bulk Micropub creation.
     let postUrl;
     try {
       const postContent = formatPostContent(row);
@@ -160,10 +161,11 @@ async function syncHistoricalPosts() {
     } catch (err) {
       console.error(`  ❌ Post creation failed: ${err.message}`); // eslint-disable-line no-console
       stats.failed++;
+      await new Promise(r => setTimeout(r, MICROPUB_DELAY_MS));
       continue;
     }
 
-    // Pause between Micropub calls — micro.blog silently drops posts under rapid bulk creation
+    // Pause between successful Micropub calls
     await new Promise(r => setTimeout(r, MICROPUB_DELAY_MS));
 
     // Write URL back to column H (isNewPost=false: don't write timestamp to column I —


### PR DESCRIPTION
## Problem

`sync-historical-posts.js` submitted 289 Micropub post creation calls in rapid succession during recovery. micro.blog accepts them all with HTTP 202 but silently drops posts when too many arrive without pausing. The result: the script reports 344 posts created with 0 failures, but 288 posts never actually appear on the site.

## Fix

Add a 3-second pause (`MICROPUB_DELAY_MS = 3000`) between each Micropub post creation call. This keeps throughput at ~12 posts/min. The existing `SHEETS_WRITE_DELAY_MS = 1500` for Google Sheets writes is unchanged.

At 289 rows × 4.5s per row the recovery now takes ~22 minutes instead of ~5 minutes, but all posts actually persist.

## Note

This pattern (`MICROPUB_DELAY_MS`) should be added to any future script that creates posts in bulk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved historical post synchronization reliability during bulk operations by adding Micropub-specific pacing between requests to prevent dropped posts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/content-manager/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->