### PR TITLE
fix(sync): include historical tab URLs in orphan cleanup check

### DIFF
--- a/src/sync-content.js
+++ b/src/sync-content.js
@@ -1617,14 +1617,33 @@ async function syncContent() {
     log(`Posts with managed categories: ${categorizedPosts.length}`, 'DEBUG');
     log(`Uncategorized posts (ignored): ${existingPosts.size - categorizedPosts.length}`, 'DEBUG');
 
-    // Build set of all post URLs from spreadsheet
+    // Build set of all known post URLs from Sheet1 (the active sync tab)
     const spreadsheetUrls = new Set(
       validRows
         .filter(row => row.microblogUrl) // Only rows with Micro.blog URLs
         .map(row => row.microblogUrl)
     );
 
-    log(`Posts in spreadsheet: ${spreadsheetUrls.size}`, 'DEBUG');
+    // Also load URLs from the historical tab so its posts are not treated as orphans.
+    // The historical tab is managed by sync-historical-posts.js, not this daily sync.
+    // We read it here only to exclude those URLs from orphan deletion.
+    try {
+      const historicalRes = await withRetry(
+        () => sheets.spreadsheets.values.get({
+          spreadsheetId: SPREADSHEET_ID,
+          range: `${HISTORICAL_TAB_NAME}!H:H`,
+        }),
+        `Read ${HISTORICAL_TAB_NAME} URLs for orphan check`
+      );
+      (historicalRes.data.values || []).slice(1).forEach(row => {
+        const url = (row[0] || '').trim();
+        if (url) spreadsheetUrls.add(url);
+      });
+    } catch (err) {
+      log(`Warning: could not read ${HISTORICAL_TAB_NAME} for orphan check — historical posts may be incorrectly deleted: ${err.message}`, 'WARN');
+    }
+
+    log(`Posts in spreadsheet (both tabs): ${spreadsheetUrls.size}`, 'DEBUG');
 
     // Find orphaned posts: exist in Micro.blog but not in spreadsheet
     const orphanedPosts = categorizedPosts.filter(([url, post]) => {

--- a/src/sync-content.js
+++ b/src/sync-content.js
@@ -1640,7 +1640,8 @@ async function syncContent() {
         if (url) spreadsheetUrls.add(url);
       });
     } catch (err) {
-      log(`Warning: could not read ${HISTORICAL_TAB_NAME} for orphan check — historical posts may be incorrectly deleted: ${err.message}`, 'WARN');
+      log(`Error: could not read ${HISTORICAL_TAB_NAME} for orphan check — skipping orphan deletion to avoid deleting valid historical posts: ${err.message}`, 'ERROR');
+      return; // Fail closed: do not run orphan deletion with an incomplete URL set
     }
 
     log(`Posts in spreadsheet (both tabs): ${spreadsheetUrls.size}`, 'DEBUG');


### PR DESCRIPTION
## What broke

The daily sync's orphaned-post cleanup queries all categorized micro.blog posts and deletes any whose URL is not in the spreadsheet. After PR #62 removed the `2024 & earlier` tab from the main sync loop, the cleanup only knew about Sheet1 URLs. Posts created by `sync-historical-posts.js` (tracked in `2024 & earlier`) were deleted as "orphaned" on every daily sync run.

This caused a third round of post deletions on May 23: 288 recovery posts created by `sync-historical-posts.js` were wiped within hours by the next daily sync.

## Fix

Load column H URLs from the `2024 & earlier` tab during the orphan check and add them to the known-URL set. Posts tracked there are excluded from orphan deletion. The historical tab is still not used for new post creation — only for orphan exclusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Orphan post detection now considers URLs from both current and historical records, preventing managed posts from being incorrectly deleted.
  * If historical records cannot be read, the deletion step is skipped to avoid accidental removals.
  * Debug logging improved to report the combined count of known URLs from both sources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/content-manager/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->