### PR TITLE
fix: treat empty status as pending in social queue dispatch

### DIFF
--- a/src/social-posts-queue.js
+++ b/src/social-posts-queue.js
@@ -174,7 +174,7 @@ async function fetchAllSocialPosts() {
 async function fetchOldestPendingPost() {
   const posts = await fetchAllSocialPosts();
   const pending = posts.filter(p =>
-    p.status === 'pending' && p.postType !== 'short' && !isMicroblogOnly(p)
+    (!p.status || p.status === 'pending') && p.postType !== 'short' && !isMicroblogOnly(p)
   );
   return pending.length > 0 ? pending[0] : null;
 }
@@ -191,7 +191,7 @@ async function fetchOldestPendingPost() {
 async function fetchOldestPendingGroup() {
   const posts = await fetchAllSocialPosts();
   const pending = posts.filter(p =>
-    p.status === 'pending' && p.postType !== 'short' && !isMicroblogOnly(p)
+    (!p.status || p.status === 'pending') && p.postType !== 'short' && !isMicroblogOnly(p)
   );
 
   if (pending.length === 0) return [];
@@ -213,7 +213,7 @@ async function fetchOldestPendingGroup() {
 async function fetchOldestPendingMicroblogPost() {
   const posts = await fetchAllSocialPosts();
   const pending = posts.filter(p =>
-    p.status === 'pending' && p.postType !== 'short' && isMicroblogOnly(p)
+    (!p.status || p.status === 'pending') && p.postType !== 'short' && isMicroblogOnly(p)
   );
   return pending.length > 0 ? pending[0] : null;
 }

--- a/tests/social-posts-queue.test.js
+++ b/tests/social-posts-queue.test.js
@@ -5,7 +5,7 @@
 jest.mock('googleapis');
 
 const { google } = require('googleapis');
-const { parseSocialPostRows, filterPostsForDate, fetchOldestPendingPost, fetchRecentShortRows } = require('../src/social-posts-queue');
+const { parseSocialPostRows, filterPostsForDate, fetchOldestPendingPost, fetchOldestPendingGroup, fetchOldestPendingMicroblogPost, fetchRecentShortRows } = require('../src/social-posts-queue');
 
 // Schema columns (0-indexed):
 // A(0)=Show, B(1)=Episode/Short Title, C(2)=Post Type, D(3)=Post Text,
@@ -247,6 +247,103 @@ describe('fetchOldestPendingPost', () => {
 
     const result = await fetchOldestPendingPost();
     expect(result.title).toBe('Episode');
+  });
+
+  test('treats empty status as pending', async () => {
+    const header = ['Show', 'Title', 'Post Type', 'Post Text', 'YouTube URL', 'Alt Text', 'Scheduled Date', 'Platforms', 'Status', 'LI', 'BSky', 'Masto', 'MB'];
+    const emptyStatusRow = makeRow({ title: 'New Row', status: '' });
+    makeSheetsMock([header, emptyStatusRow]);
+
+    const result = await fetchOldestPendingPost();
+    expect(result).not.toBeNull();
+    expect(result.title).toBe('New Row');
+  });
+});
+
+describe('fetchOldestPendingGroup', () => {
+  let mockGet;
+
+  function makeSheetsMock(rows) {
+    mockGet = jest.fn().mockResolvedValue({ data: { values: rows } });
+    google.sheets.mockReturnValue({ spreadsheets: { values: { get: mockGet } } });
+    google.auth = { GoogleAuth: jest.fn().mockImplementation(() => ({})) };
+  }
+
+  beforeEach(() => {
+    process.env.GOOGLE_SERVICE_ACCOUNT_JSON = JSON.stringify({ type: 'service_account' });
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+    jest.clearAllMocks();
+  });
+
+  test('treats empty status as pending', async () => {
+    const header = ['Show', 'Title', 'Post Type', 'Post Text', 'YouTube URL', 'Alt Text', 'Scheduled Date', 'Platforms', 'Status', 'LI', 'BSky', 'Masto', 'MB', 'Group ID'];
+    const row = makeRow({ title: 'Headlamp', platforms: 'linkedin', status: '', groupId: 'headlamp-g' });
+    makeSheetsMock([header, row]);
+
+    const result = await fetchOldestPendingGroup();
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Headlamp');
+  });
+
+  test('returns all pending rows sharing a group id', async () => {
+    const header = ['Show', 'Title', 'Post Type', 'Post Text', 'YouTube URL', 'Alt Text', 'Scheduled Date', 'Platforms', 'Status', 'LI', 'BSky', 'Masto', 'MB', 'Group ID'];
+    const li = makeRow({ title: 'Ep', platforms: 'linkedin', status: '', groupId: 'ep-g' });
+    const masto = makeRow({ title: 'Ep', platforms: 'mastodon', status: '', groupId: 'ep-g' });
+    const bsky = makeRow({ title: 'Ep', platforms: 'bluesky', status: '', groupId: 'ep-g' });
+    makeSheetsMock([header, li, masto, bsky]);
+
+    const result = await fetchOldestPendingGroup();
+    expect(result).toHaveLength(3);
+  });
+
+  test('returns empty array when only posted rows exist', async () => {
+    const header = ['Show', 'Title', 'Post Type', 'Post Text', 'YouTube URL', 'Alt Text', 'Scheduled Date', 'Platforms', 'Status', 'LI', 'BSky', 'Masto', 'MB', 'Group ID'];
+    const posted = makeRow({ status: 'posted' });
+    makeSheetsMock([header, posted]);
+
+    const result = await fetchOldestPendingGroup();
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('fetchOldestPendingMicroblogPost', () => {
+  let mockGet;
+
+  function makeSheetsMock(rows) {
+    mockGet = jest.fn().mockResolvedValue({ data: { values: rows } });
+    google.sheets.mockReturnValue({ spreadsheets: { values: { get: mockGet } } });
+    google.auth = { GoogleAuth: jest.fn().mockImplementation(() => ({})) };
+  }
+
+  beforeEach(() => {
+    process.env.GOOGLE_SERVICE_ACCOUNT_JSON = JSON.stringify({ type: 'service_account' });
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_JSON;
+    jest.clearAllMocks();
+  });
+
+  test('treats empty status as pending for micro.blog-only rows', async () => {
+    const header = ['Show', 'Title', 'Post Type', 'Post Text', 'YouTube URL', 'Alt Text', 'Scheduled Date', 'Platforms', 'Status', 'LI', 'BSky', 'Masto', 'MB', 'Group ID'];
+    const row = makeRow({ title: 'MB Only', platforms: 'micro.blog', status: '' });
+    makeSheetsMock([header, row]);
+
+    const result = await fetchOldestPendingMicroblogPost();
+    expect(result).not.toBeNull();
+    expect(result.title).toBe('MB Only');
+  });
+
+  test('returns null when only non-microblog rows are pending', async () => {
+    const header = ['Show', 'Title', 'Post Type', 'Post Text', 'YouTube URL', 'Alt Text', 'Scheduled Date', 'Platforms', 'Status', 'LI', 'BSky', 'Masto', 'MB', 'Group ID'];
+    const row = makeRow({ platforms: 'linkedin,bluesky', status: '' });
+    makeSheetsMock([header, row]);
+
+    const result = await fetchOldestPendingMicroblogPost();
+    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- `fetchOldestPendingGroup`, `fetchOldestPendingPost`, and `fetchOldestPendingMicroblogPost` all filtered with `status === 'pending'`, but rows newly added to the Social Posts Queue have an empty status string — not the literal string `'pending'`
- This caused all three Headlamp LinkedIn/Mastodon/Bluesky rows (empty status since they were written) to be silently skipped on every daily run since May 13
- Fix: change the filter from `status === 'pending'` to `!status || status === 'pending'` in all three functions
- No change to how `'posted'` or `'failed'` rows are handled

## Test plan

- [ ] `fetchOldestPendingPost` — new test: returns a row with empty status
- [ ] `fetchOldestPendingGroup` — new tests: returns group of empty-status rows, still skips posted rows
- [ ] `fetchOldestPendingMicroblogPost` — new test: returns micro.blog-only row with empty status
- [ ] Full suite: 441 tests pass
- [ ] Verify next pipeline run dispatches the Headlamp LinkedIn/Mastodon/Bluesky rows (rows 6–8)
- [ ] Update PROGRESS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pending-status filtering logic across queue-fetching operations to treat rows with missing or empty status values as pending, ensuring more accurate queue handling for social media posts.

* **Tests**
  * Expanded test coverage for pending-status filtering logic, including new tests for handling empty status values and group-based post fetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/content-manager/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->