### PR TITLE
fix: normalize Video-Livestream and Edited-video type variants to Video

### DIFF
--- a/src/sync-content.js
+++ b/src/sync-content.js
@@ -432,10 +432,12 @@ function parseRow(row, rowIndex, isHeaderRow = false) {
   // Extract fields by column position (A-K)
   const [name, type, show, date, location, confirmed, link, microblogUrl, , rawHighlight, rawPriority] = row;
 
-  // Normalize type: "Presentation" (singular) → "Presentations" (plural)
+  // Normalize spreadsheet type variants to canonical values
   let normalizedType = (type || '').trim();
   if (normalizedType === 'Presentation') {
     normalizedType = 'Presentations';
+  } else if (normalizedType === 'Video - Livestream' || normalizedType.toLowerCase() === 'edited video') {
+    normalizedType = 'Video';
   }
 
   const parsedPriority = parseInt(rawPriority, 10);

--- a/tests/sync-content.test.js
+++ b/tests/sync-content.test.js
@@ -72,6 +72,28 @@ describe('parseRow', () => {
     });
   });
 
+  describe('type normalization', () => {
+    test('normalizes "Presentation" to "Presentations"', () => {
+      const result = parseRow(makeRow({ type: 'Presentation' }), 1);
+      expect(result.type).toBe('Presentations');
+    });
+
+    test('normalizes "Video - Livestream" to "Video"', () => {
+      const result = parseRow(makeRow({ type: 'Video - Livestream' }), 1);
+      expect(result.type).toBe('Video');
+    });
+
+    test('normalizes "Edited video" to "Video"', () => {
+      const result = parseRow(makeRow({ type: 'Edited video' }), 1);
+      expect(result.type).toBe('Video');
+    });
+
+    test('normalizes "Edited Video" (capital V) to "Video"', () => {
+      const result = parseRow(makeRow({ type: 'Edited Video' }), 1);
+      expect(result.type).toBe('Video');
+    });
+  });
+
   describe('backward compatibility', () => {
     test('parses existing fields correctly alongside new highlight fields', () => {
       const result = parseRow(makeRow({ name: 'My Talk', type: 'Video', link: 'https://youtu.be/abc', highlight: 'Yes', highlightPriority: '5' }), 2);


### PR DESCRIPTION
## Summary

- Rows typed `Video - Livestream` or `Edited video`/`Edited Video` were silently skipped as invalid type, blocking them from being posted to Micro.blog
- Adds normalization for these variants (alongside the existing `Presentation` → `Presentations` normalization) so they resolve to `Video`
- Covers the immediate case: the kagent Enlightning episode (`Video - Livestream`) in the production spreadsheet was never posted because of this

## Test plan

- [ ] 4 new unit tests added to `tests/sync-content.test.js` covering `Video - Livestream`, `Edited video`, and `Edited Video` normalization — all pass
- [ ] Full suite: 36/36 tests pass
- [ ] Dry-run confirms kagent row is now picked up: `vals exec -f .vals.yaml -- node src/sync-content.js --dry-run`
- [ ] Update PROGRESS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved content type normalization to properly handle additional video type variants, including livestream and case-insensitive "edited video" entries.

* **Tests**
  * Added comprehensive test coverage for type normalization validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wiggitywhitney/content-manager/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->