### PR TITLE
chore: upgrade GitHub Actions to Node.js 24 before June 2 cutover

### DIFF
--- a/.github/workflows/daily-sync.yml
+++ b/.github/workflows/daily-sync.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -78,10 +78,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,6 +7,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 ## [Unreleased]
 
 ### Changed
+- (2026-06-01) Updated GitHub Actions workflow to use `actions/checkout@v6` and `actions/setup-node@v6`, both built on Node.js 24, ahead of GitHub's June 2, 2026 forced cutover from Node.js 20.
 - (2026-05-16) Daily content sync now runs seven days a week instead of Monday–Friday only, so the backlog of staged career posts clears faster on weekends.
 
 ### Fixed

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,7 +7,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 ## [Unreleased]
 
 ### Changed
-- (2026-06-01) Updated GitHub Actions workflow to use `actions/checkout@v6` and `actions/setup-node@v6`, both built on Node.js 24, ahead of GitHub's June 2, 2026 forced cutover from Node.js 20.
+- (2026-06-01) Updated GitHub Actions workflow to use `actions/checkout@v6` and `actions/setup-node@v6`, which use the Node.js 24 runtime, ahead of GitHub's June 16, 2026 default cutover (Node.js 20 removed in fall 2026).
 - (2026-05-16) Daily content sync now runs seven days a week instead of Monday–Friday only, so the backlog of staged career posts clears faster on weekends.
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Updates `actions/checkout` from v4 to v6 in all three jobs (`integration-tests`, `e2e-tests`, `daily-sync`)
- Updates `actions/setup-node` from v4 to v6 in all three jobs
- Both v6 releases use Node.js 24 internally, ahead of GitHub's forced migration on June 2, 2026

Closes #68

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` to confirm all three jobs complete successfully
- [ ] Verify PROGRESS.md entry is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow steps to the latest stable actions (checkout v6 and setup-node v6) across relevant jobs.
  * Noted CI runtime update to Node.js 24 in project progress to prepare for the upcoming Node.js 20 cutover.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->