### PR TITLE
Fix gist post image: support direct image URLs in fetchThumbnail

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,6 +7,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 ## [Unreleased]
 
 ### Fixed
+- (2026-06-04) Fixed a bug where gist posts dispatched with no image when column E held a direct CDN image URL (e.g. `https://i.ytimg.com/vi/.../maxresdefault.jpg`). `fetchThumbnail` only recognized YouTube video page URLs and SDI episode URLs; direct image URLs threw "Unrecognized YouTube URL format" and the error was swallowed, resulting in imageless posts. Direct image URLs are now fetched as-is and returned as a buffer, throwing on non-200 responses. The Social Instructions spreadsheet tab was updated to document the gist row schema: column E holds a board-notes GitHub URL (`https://raw.githubusercontent.com/wiggitywhitney/board-notes/main/thunder/{episode-slug}/board.png`), and gist rows use one row with all platforms comma-separated — no Group ID.
 - (2026-06-04) Fixed a bug where social dispatch would proceed on social-priority days even if career had already posted that day. The `checkCareerPostedToday()` gate was only applied on career-priority days; removing that condition means career-already-posted skips social dispatch on any day, correctly enforcing the one-post-per-day limit.
 
 ### Changed

--- a/src/fetch-thumbnail.js
+++ b/src/fetch-thumbnail.js
@@ -45,8 +45,9 @@ function extractVideoId(youtubeUrl) {
  * throws on other failures.
  * For SDI episode URLs: parses the SDI RSS feed to find the episode artwork,
  * returns null (with console.warn) on RSS fetch failure or missing episode.
+ * For any other URL: fetches the URL directly, throws on non-200.
  *
- * @param {string} url - YouTube video URL or SDI episode URL
+ * @param {string} url - YouTube video URL, SDI episode URL, or direct image URL
  * @returns {Promise<Buffer|null>} Image bytes as a Buffer, or null if SDI lookup fails
  */
 async function fetchThumbnail(url) {
@@ -54,28 +55,57 @@ async function fetchThumbnail(url) {
     return fetchSdiThumbnail(url);
   }
 
-  const videoId = extractVideoId(url);
-  const maxresUrl = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
-  const hqUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+  if (isYoutubeUrl(url)) {
+    const videoId = extractVideoId(url);
+    const maxresUrl = `https://i.ytimg.com/vi/${videoId}/maxresdefault.jpg`;
+    const hqUrl = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
 
-  const maxresRes = await fetch(maxresUrl);
-  if (maxresRes.ok) {
-    return Buffer.from(await maxresRes.arrayBuffer());
+    const maxresRes = await fetch(maxresUrl);
+    if (maxresRes.ok) {
+      return Buffer.from(await maxresRes.arrayBuffer());
+    }
+
+    if (maxresRes.status !== 404) {
+      throw new Error(`Failed to fetch thumbnail (${maxresRes.status}): ${maxresUrl}`);
+    }
+
+    const hqRes = await fetch(hqUrl);
+    if (!hqRes.ok) {
+      throw new Error(`Failed to fetch thumbnail (${hqRes.status}): ${hqUrl}`);
+    }
+
+    return Buffer.from(await hqRes.arrayBuffer());
   }
 
-  if (maxresRes.status !== 404) {
-    throw new Error(`Failed to fetch thumbnail (${maxresRes.status}): ${maxresUrl}`);
+  try {
+    new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
   }
 
-  const hqRes = await fetch(hqUrl);
-  if (!hqRes.ok) {
-    throw new Error(`Failed to fetch thumbnail (${hqRes.status}): ${hqUrl}`);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch image (${res.status}): ${url}`);
   }
-
-  return Buffer.from(await hqRes.arrayBuffer());
+  return Buffer.from(await res.arrayBuffer());
 }
 
 const SDI_FEED_URL = 'https://feeds.fireside.fm/softwaredefinedinterviews/rss';
+
+/**
+ * Returns true if the URL is a YouTube video URL.
+ *
+ * @param {string} url
+ * @returns {boolean}
+ */
+function isYoutubeUrl(url) {
+  try {
+    const h = new URL(url).hostname;
+    return h === 'youtu.be' || h === 'youtube.com' || h === 'www.youtube.com';
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Returns true if the URL is a Software Defined Interviews episode URL.
@@ -144,4 +174,4 @@ async function fetchSdiThumbnail(episodeUrl) {
   }
 }
 
-module.exports = { fetchThumbnail, extractVideoId, isSdiUrl, fetchSdiThumbnail };
+module.exports = { fetchThumbnail, extractVideoId, isYoutubeUrl, isSdiUrl, fetchSdiThumbnail };

--- a/tests/fetch-thumbnail.test.js
+++ b/tests/fetch-thumbnail.test.js
@@ -104,8 +104,40 @@ describe('fetchThumbnail', () => {
   });
 
   test('throws on malformed URL', async () => {
-    await expect(fetchThumbnail('not-a-url')).rejects.toThrow('Invalid YouTube URL');
+    await expect(fetchThumbnail('not-a-url')).rejects.toThrow('Invalid URL');
     expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('fetchThumbnail — direct image URLs', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('returns buffer from a direct image URL', async () => {
+    const FAKE_IMAGE_BYTES = Buffer.from('fake-jpeg-data');
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(FAKE_IMAGE_BYTES.buffer),
+    });
+
+    const result = await fetchThumbnail('https://i.ytimg.com/vi/RNaa_48LWBY/maxresdefault.jpg');
+    expect(Buffer.isBuffer(result)).toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith('https://i.ytimg.com/vi/RNaa_48LWBY/maxresdefault.jpg');
+  });
+
+  test('throws when direct image URL returns non-200', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false, status: 403 });
+
+    await expect(
+      fetchThumbnail('https://raw.githubusercontent.com/wiggitywhitney/board-notes/main/thunder/ep19/board.png')
+    ).rejects.toThrow('Failed to fetch image (403)');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

- Extends `fetchThumbnail` to handle direct image URLs (e.g., CDN URLs, GitHub raw URLs). Previously, any URL that wasn't a YouTube video page URL or SDI episode URL threw `Unrecognized YouTube URL format`, which `post-social-content.js` swallowed — sending gist posts with no image.
- Adds `isYoutubeUrl()` helper to cleanly separate the YouTube and direct-image routing paths.
- Throws on non-200 direct image responses (matching YouTube path behavior); throws on malformed URLs before attempting fetch.
- Updates Social Instructions spreadsheet tab to document the gist row schema: column E = board-notes board image URL, one row per gist with comma-separated platforms, no Group ID needed.

## Test plan

- [x] New tests: `returns buffer from a direct image URL`, `throws when direct image URL returns non-200`
- [x] Updated test: `throws on malformed URL` now expects `Invalid URL` (not `Invalid YouTube URL`)
- [x] Full test suite: 468/468 passing
- [ ] Verify Social Instructions tab updates look correct in the Staged spreadsheet

Closes #75

- [x] Update `PROGRESS.md` with a feature-level entry describing what changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thumbnail fetching for gist posts with direct image URLs. Images are now correctly retrieved and displayed with proper error handling for failed requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->