### PR TITLE
fix(e2e): mask same-day posted rows before dispatch pipeline test

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,6 +7,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 ## [Unreleased]
 
 ### Fixed
+- (2026-06-16) Fixed the e2e dispatch pipeline test failing when the daily social dispatch had already run that day. The social-guard checks the Social Posts Queue for any row with `status=posted` and today's date; when found, it blocks dispatch entirely — causing the test's DRY_RUN assertion to never be reached. The fix adds a masking step in `beforeAll` that temporarily rewrites those rows' scheduled dates to a known past date before spawning the pipeline script, making the guard see a clean day. `afterAll` restores the original dates before deleting the test row, so real data is never durably altered.
 - (2026-06-15) Dispatcher now skips platforms that already have a post URL when retrying a partially-failed row. Previously, resetting a row to pending after partial success (e.g., LinkedIn failed, Bluesky/Mastodon succeeded) would re-post to all platforms in the `platforms` column — including ones that had already posted successfully — creating duplicate posts. Each platform gate in `dispatchPost` now checks the corresponding URL column (Bluesky: `bskyPostUrl`, Mastodon: `mastodonPostUrl`, LinkedIn: `linkedinPostUrl`, micro.blog: `microblogPostUrl`) and skips the platform if a URL is already present. Rows where all platforms are already posted are correctly marked `posted` rather than `failed`.
 
 ### Added

--- a/tests/e2e/dispatch-pipeline.e2e.test.js
+++ b/tests/e2e/dispatch-pipeline.e2e.test.js
@@ -66,20 +66,34 @@ describe('Dispatch pipeline e2e', () => {
     });
     const rows = allRows.data.values || [];
     // Row 0 is the header; data rows start at index 1 (sheet row 2)
-    for (let i = 1; i < rows.length; i++) {
-      const row = rows[i];
-      const scheduledDate = (row[6] || '').trim(); // COL.SCHEDULED_DATE = 6
-      const status = (row[8] || '').trim().toLowerCase(); // COL.STATUS = 8
-      if (status === 'posted' && scheduledDate.startsWith(today)) {
-        const rowIndex = i + 1; // convert 0-based array index to 1-based sheet row
-        maskedRows.push({ rowIndex, originalDate: scheduledDate });
+    try {
+      for (let i = 1; i < rows.length; i++) {
+        const row = rows[i];
+        const scheduledDate = (row[6] || '').trim(); // COL.SCHEDULED_DATE = 6
+        const status = (row[8] || '').trim().toLowerCase(); // COL.STATUS = 8
+        if (status === 'posted' && scheduledDate.startsWith(today)) {
+          const rowIndex = i + 1; // convert 0-based array index to 1-based sheet row
+          maskedRows.push({ rowIndex, originalDate: scheduledDate });
+          await sheets.spreadsheets.values.update({
+            spreadsheetId: STAGED_SPREADSHEET_ID,
+            range: `${SOCIAL_POSTS_TAB}!G${rowIndex}`,
+            valueInputOption: 'USER_ENTERED',
+            resource: { values: [[GUARD_MASK_DATE]] },
+          });
+        }
+      }
+    } catch (err) {
+      // Roll back any rows already masked so we don't leave the sheet in a partial state.
+      for (const { rowIndex, originalDate } of maskedRows) {
         await sheets.spreadsheets.values.update({
           spreadsheetId: STAGED_SPREADSHEET_ID,
           range: `${SOCIAL_POSTS_TAB}!G${rowIndex}`,
           valueInputOption: 'USER_ENTERED',
-          resource: { values: [[GUARD_MASK_DATE]] },
-        });
+          resource: { values: [[originalDate]] },
+        }).catch(() => {}); // best effort
       }
+      maskedRows = [];
+      throw new Error(`Failed to mask rows for e2e test: ${err.message}`);
     }
 
     // Insert test row: platforms bluesky,mastodon; postType episode; scheduledDate today
@@ -133,12 +147,16 @@ describe('Dispatch pipeline e2e', () => {
 
     // Restore any rows whose scheduledDate was temporarily masked before the run.
     for (const { rowIndex, originalDate } of maskedRows) {
-      await sheets.spreadsheets.values.update({
-        spreadsheetId: STAGED_SPREADSHEET_ID,
-        range: `${SOCIAL_POSTS_TAB}!G${rowIndex}`,
-        valueInputOption: 'USER_ENTERED',
-        resource: { values: [[originalDate]] },
-      });
+      try {
+        await sheets.spreadsheets.values.update({
+          spreadsheetId: STAGED_SPREADSHEET_ID,
+          range: `${SOCIAL_POSTS_TAB}!G${rowIndex}`,
+          valueInputOption: 'USER_ENTERED',
+          resource: { values: [[originalDate]] },
+        });
+      } catch (err) {
+        console.error(`Failed to restore row ${rowIndex} to ${originalDate}: ${err.message}`);
+      }
     }
 
     if (!testRowIndex || !sheetId) return;

--- a/tests/e2e/dispatch-pipeline.e2e.test.js
+++ b/tests/e2e/dispatch-pipeline.e2e.test.js
@@ -31,10 +31,16 @@ function getTodayDate() {
   return new Date().toISOString().slice(0, 10);
 }
 
+// Date used as a placeholder when temporarily masking already-posted rows so the guard won't fire.
+const GUARD_MASK_DATE = '2020-01-01';
+
 describe('Dispatch pipeline e2e', () => {
   let testRowIndex; // 1-based sheet row index of the inserted test row
   let sheetId;     // numeric sheet ID for batchUpdate
   let pipelineOutput; // shared stdout from the single DRY_RUN pipeline run
+  // Rows with status=posted and scheduledDate=today that were temporarily masked before the run.
+  // Each entry: { rowIndex: number, originalDate: string }
+  let maskedRows = [];
 
   beforeAll(async () => {
     if (!process.env.GOOGLE_SERVICE_ACCOUNT_JSON) {
@@ -49,6 +55,32 @@ describe('Dispatch pipeline e2e', () => {
     const tab = (meta.data.sheets || []).find(s => s.properties.title === SOCIAL_POSTS_TAB);
     if (!tab) throw new Error(`Tab "${SOCIAL_POSTS_TAB}" not found`);
     sheetId = tab.properties.sheetId;
+
+    // Mask any already-posted rows for today so the social-guard won't block dispatch.
+    // The guard fires when it sees status=posted + scheduledDate=today; temporarily
+    // rewriting those dates to GUARD_MASK_DATE makes the guard see a clean day.
+    // afterAll restores the original dates regardless of test outcome.
+    const allRows = await sheets.spreadsheets.values.get({
+      spreadsheetId: STAGED_SPREADSHEET_ID,
+      range: `${SOCIAL_POSTS_TAB}!A:I`,
+    });
+    const rows = allRows.data.values || [];
+    // Row 0 is the header; data rows start at index 1 (sheet row 2)
+    for (let i = 1; i < rows.length; i++) {
+      const row = rows[i];
+      const scheduledDate = (row[6] || '').trim(); // COL.SCHEDULED_DATE = 6
+      const status = (row[8] || '').trim().toLowerCase(); // COL.STATUS = 8
+      if (status === 'posted' && scheduledDate.startsWith(today)) {
+        const rowIndex = i + 1; // convert 0-based array index to 1-based sheet row
+        maskedRows.push({ rowIndex, originalDate: scheduledDate });
+        await sheets.spreadsheets.values.update({
+          spreadsheetId: STAGED_SPREADSHEET_ID,
+          range: `${SOCIAL_POSTS_TAB}!G${rowIndex}`,
+          valueInputOption: 'USER_ENTERED',
+          resource: { values: [[GUARD_MASK_DATE]] },
+        });
+      }
+    }
 
     // Insert test row: platforms bluesky,mastodon; postType episode; scheduledDate today
     // COL order: Show, Title, PostType, PostText, YouTubeURL, AltText, ScheduledDate, Platforms, Status
@@ -97,9 +129,20 @@ describe('Dispatch pipeline e2e', () => {
   });
 
   afterAll(async () => {
+    const sheets = getSheets();
+
+    // Restore any rows whose scheduledDate was temporarily masked before the run.
+    for (const { rowIndex, originalDate } of maskedRows) {
+      await sheets.spreadsheets.values.update({
+        spreadsheetId: STAGED_SPREADSHEET_ID,
+        range: `${SOCIAL_POSTS_TAB}!G${rowIndex}`,
+        valueInputOption: 'USER_ENTERED',
+        resource: { values: [[originalDate]] },
+      });
+    }
+
     if (!testRowIndex || !sheetId) return;
 
-    const sheets = getSheets();
     await sheets.spreadsheets.batchUpdate({
       spreadsheetId: STAGED_SPREADSHEET_ID,
       resource: {


### PR DESCRIPTION
## Summary

- The e2e dispatch pipeline test failed intermittently when the daily social dispatch had already run that day
- The social-guard reads the Social Posts Queue for any row with `status=posted` and today's date; finding one blocks all dispatch, so the DRY_RUN assertion was never reached
- `beforeAll` now temporarily rewrites those rows' scheduled dates to `2020-01-01` before spawning the pipeline, making the guard see a clean day
- `afterAll` restores original dates before deleting the test row — no production data is durably altered

## Test plan

- [ ] `npm run test:e2e` passes when run any time of day, including after the daily dispatch has already fired
- [ ] All 524 unit tests continue to pass (`npm test`)
- [ ] `afterAll` restores masked rows' dates correctly regardless of test outcome

Closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixed a failing e2e dispatch pipeline test by ensuring previously posted “today” entries don’t block the social dispatch guard during DRY_RUN.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->