### PR TITLE
Enable two-posts-per-day mode

### DIFF
--- a/.github/workflows/daily-sync.yml
+++ b/.github/workflows/daily-sync.yml
@@ -78,7 +78,7 @@ jobs:
     env:
       # Set to 'true' to enable two-post-per-day mode (morning=social, evening=career).
       # Set to 'false' (default) to restore one-post-per-day behavior — evening cron runs but skips posting.
-      TWO_POSTS_PER_DAY: 'false'
+      TWO_POSTS_PER_DAY: 'true'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/daily-sync.yml
+++ b/.github/workflows/daily-sync.yml
@@ -76,8 +76,8 @@ jobs:
       group: daily-sync-${{ github.ref }}
       cancel-in-progress: true
     env:
-      # Set to 'true' to enable two-post-per-day mode (morning=social, evening=career).
-      # Set to 'false' (default) to restore one-post-per-day behavior — evening cron runs but skips posting.
+      # Set to 'true' (default) to enable two-post-per-day mode (morning=social, evening=career).
+      # Set to 'false' to restore one-post-per-day behavior — evening cron runs but skips posting.
       TWO_POSTS_PER_DAY: 'true'
 
     steps:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,7 +7,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 ## [Unreleased]
 
 ### Changed
-- (2026-06-19) Enabled two-posts-per-day mode by default. Set `TWO_POSTS_PER_DAY=true` in the daily workflow so the evening cron dispatches a career post every day instead of being skipped. The feature was implemented in the previous session; this change activates it.
+- (2026-06-19) Enabled two-posts-per-day mode by default. Set `TWO_POSTS_PER_DAY=true` in the daily workflow so the evening cron runs the career sync path each evening instead of being skipped. The feature was implemented in the previous session; this change activates it.
 
 ### Added
 - (2026-06-18) Added two-posts-per-day mode to drain the social post backlog. A `TWO_POSTS_PER_DAY` env var in `daily-sync.yml` (default `false`) enables two cron slots: morning at 8am CT (13:00 UTC) for social content and evening at 4pm CT (21:00 UTC) for career content. When enabled, the career-posted-today guard is bypassed for social dispatch so both can go out on the same day. When disabled, the evening cron exits early via a `skip_run` guard and one-post-per-day behavior is fully preserved. A `getSlot()` helper detects which cron fired by UTC hour. The career sync step now runs in every evening slot in two-post mode regardless of day parity, fixing a bug where even-day evenings were skipped entirely.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -6,6 +6,9 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 
 ## [Unreleased]
 
+### Changed
+- (2026-06-19) Enabled two-posts-per-day mode by default. Set `TWO_POSTS_PER_DAY=true` in the daily workflow so the evening cron dispatches a career post every day instead of being skipped. The feature was implemented in the previous session; this change activates it.
+
 ### Added
 - (2026-06-18) Added two-posts-per-day mode to drain the social post backlog. A `TWO_POSTS_PER_DAY` env var in `daily-sync.yml` (default `false`) enables two cron slots: morning at 8am CT (13:00 UTC) for social content and evening at 4pm CT (21:00 UTC) for career content. When enabled, the career-posted-today guard is bypassed for social dispatch so both can go out on the same day. When disabled, the evening cron exits early via a `skip_run` guard and one-post-per-day behavior is fully preserved. A `getSlot()` helper detects which cron fired by UTC hour. The career sync step now runs in every evening slot in two-post mode regardless of day parity, fixing a bug where even-day evenings were skipped entirely.
 

--- a/tests/daily-sync-workflow.test.js
+++ b/tests/daily-sync-workflow.test.js
@@ -112,9 +112,9 @@ describe('daily-sync workflow', () => {
       expect(crons).toContain('0 21 * * *');
     });
 
-    test('daily-sync job has TWO_POSTS_PER_DAY env var defaulting to false', () => {
+    test('daily-sync job has TWO_POSTS_PER_DAY env var set to true', () => {
       const jobEnv = workflow.jobs['daily-sync'].env || {};
-      expect(jobEnv.TWO_POSTS_PER_DAY).toBe('false');
+      expect(jobEnv.TWO_POSTS_PER_DAY).toBe('true');
     });
 
     test('Determine post priority step runs before Scan for new content', () => {


### PR DESCRIPTION
## Summary

- Sets `TWO_POSTS_PER_DAY=true` in `daily-sync.yml` to activate the two-posts-per-day feature built in the previous session
- Morning cron (8am CDT) dispatches social content; evening cron (4pm CDT) dispatches career content
- Updates the workflow test to expect the new default value of `'true'`
- Verified via manual dispatch: workflow ran in evening slot; social-guard correctly detected morning post was done, career sync found no queued content (backlog empty)

## Test plan

- [ ] Manual dispatch run completed successfully (run #27851836963)
- [ ] `TWO_POSTS_PER_DAY: true` visible in job env in run logs
- [ ] Evening slot no longer exits early with "skipped" message
- [ ] All 551 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated daily post scheduling to default to **two posts per day** instead of one.
* **Documentation**
  * Refreshed **progress notes** to indicate the new default two-posts-per-day setting.
* **Tests**
  * Adjusted the daily-sync workflow test to verify the environment default now sets `TWO_POSTS_PER_DAY` to `true`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->