### PR TITLE
Revert daily-sync to one post per day

### DIFF
--- a/.github/workflows/daily-sync.yml
+++ b/.github/workflows/daily-sync.yml
@@ -76,9 +76,9 @@ jobs:
       group: daily-sync-${{ github.ref }}
       cancel-in-progress: true
     env:
-      # Set to 'true' (default) to enable two-post-per-day mode (morning=social, evening=career).
-      # Set to 'false' to restore one-post-per-day behavior — evening cron runs but skips posting.
-      TWO_POSTS_PER_DAY: 'true'
+      # Set to 'true' to enable two-post-per-day mode (morning=social, evening=career).
+      # Set to 'false' (default) to restore one-post-per-day behavior — evening cron runs but skips posting.
+      TWO_POSTS_PER_DAY: 'false'
 
     steps:
       - name: Checkout repository

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,6 +7,7 @@ Entry format: `- (YYYY-MM-DD) Description of feature-level change (PRD #X, miles
 ## [Unreleased]
 
 ### Changed
+- (2026-07-29) Reverted `daily-sync.yml` to one post per day. Set `TWO_POSTS_PER_DAY=false` (the documented default) so the evening cron once again exits early via the `skip_run` guard instead of running the career sync path. Career and social content share the single morning slot via the existing day-parity priority logic.
 - (2026-06-19) Enabled two-posts-per-day mode by default. Set `TWO_POSTS_PER_DAY=true` in the daily workflow so the evening cron runs the career sync path each evening instead of being skipped. The feature was implemented in the previous session; this change activates it.
 
 ### Added

--- a/tests/daily-sync-workflow.test.js
+++ b/tests/daily-sync-workflow.test.js
@@ -112,9 +112,9 @@ describe('daily-sync workflow', () => {
       expect(crons).toContain('0 21 * * *');
     });
 
-    test('daily-sync job has TWO_POSTS_PER_DAY env var set to true', () => {
+    test('daily-sync job has TWO_POSTS_PER_DAY env var set to false', () => {
       const jobEnv = workflow.jobs['daily-sync'].env || {};
-      expect(jobEnv.TWO_POSTS_PER_DAY).toBe('true');
+      expect(jobEnv.TWO_POSTS_PER_DAY).toBe('false');
     });
 
     test('Determine post priority step runs before Scan for new content', () => {


### PR DESCRIPTION
## Summary
- Sets `TWO_POSTS_PER_DAY` back to `false` (the documented default) in `daily-sync.yml` so only the morning cron posts; the evening run hits the `skip_run` guard and exits without posting.
- Updates the workflow test asserting the env var value to match.

## Test plan
- [x] `npx jest tests/daily-sync-workflow.test.js` — 34/34 passing
- [ ] Confirm no evening post fires on the next scheduled run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * The daily content workflow now defaults to one post per day.
  * Career and social content share the morning publishing slot, with existing priority rules determining which content is selected.
  * A second daily post can still be enabled explicitly through the workflow setting.

* **Documentation**
  * Updated release tracking to reflect the one-post-per-day default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->